### PR TITLE
Send data back to dapp after browser tx is triggered

### DIFF
--- a/src/app/components/transactionsRequests/utils.ts
+++ b/src/app/components/transactionsRequests/utils.ts
@@ -1,0 +1,36 @@
+import {
+  ExternalMethods, MESSAGE_SOURCE, TransactionResponseMessage, TxResult,
+} from 'content-scripts/message-types';
+
+interface FormatTxSignatureResponseArgs {
+  payload: string;
+  response: TxResult | 'cancel';
+}
+export function formatTxSignatureResponse({
+  payload,
+  response,
+}: FormatTxSignatureResponseArgs): TransactionResponseMessage {
+  return {
+    source: MESSAGE_SOURCE,
+    method: ExternalMethods.transactionResponse,
+    payload: {
+      transactionRequest: payload,
+      transactionResponse: response,
+    },
+  };
+}
+
+interface FinalizeTxSignatureArgs {
+  requestPayload: string;
+  data: TxResult | 'cancel';
+  tabId: number;
+}
+
+export default function finalizeTxSignature({ requestPayload, data, tabId }: FinalizeTxSignatureArgs) {
+  try {
+    const responseMessage = formatTxSignatureResponse({ payload: requestPayload, response: data });
+    chrome.tabs.sendMessage(tabId, responseMessage);
+  } catch (e) {
+    console.log(e);
+  }
+}

--- a/src/app/hooks/useSignatureRequest.ts
+++ b/src/app/hooks/useSignatureRequest.ts
@@ -46,7 +46,6 @@ function useSignatureRequest() {
     messageType: messageType as SignatureMessageType,
     tabId,
   };
-  c
 }
 export function useSignMessage(messageType: SignatureMessageType) {
   const {

--- a/src/app/hooks/useTransationRequest.ts
+++ b/src/app/hooks/useTransationRequest.ts
@@ -1,4 +1,3 @@
-import { TransactionPayload } from '@stacks/connect';
 import { decodeToken } from 'jsontokens';
 import { useLocation } from 'react-router-dom';
 
@@ -7,8 +6,11 @@ const useDappRequest = () => {
   const params = new URLSearchParams(search);
   const requestToken = params.get('request') ?? '';
   const request = decodeToken(requestToken) as any;
+  const tabId = params.get('tabId') ?? '0';
   return {
     payload: request.payload,
+    tabId,
+    requestToken,
   };
 };
 

--- a/src/app/screens/transactionRequest/index.tsx
+++ b/src/app/screens/transactionRequest/index.tsx
@@ -8,9 +8,9 @@ import useStxPendingTxData from '@hooks/useStxPendingTxData';
 import { useNavigate } from 'react-router-dom';
 import { Ring } from 'react-spinners-css';
 import styled from 'styled-components';
-import { getContractCallPromises, getTokenTransferRequest } from './helper';
 import { ContractFunction } from '@secretkeylabs/xverse-core/types/api/stacks/transaction';
 import { Coin, createDeployContractRequest } from '@secretkeylabs/xverse-core';
+import { getContractCallPromises, getTokenTransferRequest } from './helper';
 
 const LoaderContainer = styled.div((props) => ({
   display: 'flex',
@@ -21,9 +21,13 @@ const LoaderContainer = styled.div((props) => ({
 }));
 
 function TransactionRequest() {
-  const { payload } = useDappRequest();
+  const {
+    payload, tabId, requestToken,
+  } = useDappRequest();
   const navigate = useNavigate();
-  const { stxAddress, network, stxPublicKey, feeMultipliers } = useWalletSelector();
+  const {
+    stxAddress, network, stxPublicKey, feeMultipliers,
+  } = useWalletSelector();
   const [unsignedTx, setUnsignedTx] = useState<StacksTransaction>();
   const [funcMetaData, setFuncMetaData] = useState<ContractFunction | undefined>(undefined);
   const [coinsMetaData, setCoinsMetaData] = useState<Coin[] | null>(null);
@@ -42,7 +46,7 @@ function TransactionRequest() {
             stxPublicKey,
             feeMultipliers!,
             network,
-            stxPendingTxData
+            stxPendingTxData,
           );
           setUnsignedTx(unsignedSendStxTx);
           navigate('/confirm-stx-tx', {
@@ -50,6 +54,8 @@ function TransactionRequest() {
               unsignedTx: unsignedSendStxTx,
               sponosred: payload.sponsored,
               isBrowserTx: true,
+              tabId,
+              requestToken,
             },
           });
         } else if (payload.txType === 'contract_call') {
@@ -61,8 +67,7 @@ function TransactionRequest() {
           } = await getContractCallPromises(payload, stxAddress, network, stxPublicKey);
           setUnsignedTx(unSignedContractCall);
           setCoinsMetaData(coinsMetaData);
-          const invokedFuncMetaData: ContractFunction | undefined =
-            contractInterface?.functions?.find((func) => func.name === payload.functionName);
+          const invokedFuncMetaData: ContractFunction | undefined = contractInterface?.functions?.find((func) => func.name === payload.functionName);
           if (invokedFuncMetaData) {
             setFuncMetaData(invokedFuncMetaData);
           }
@@ -72,7 +77,7 @@ function TransactionRequest() {
             network,
             stxPublicKey,
             feeMultipliers!,
-            stxAddress
+            stxAddress,
           );
           setUnsignedTx(response.contractDeployTx);
           setCodeBody(response.codeBody);
@@ -92,24 +97,30 @@ function TransactionRequest() {
     );
   }
 
-  if (payload.txType === 'contract_call' && unsignedTx)
+  if (payload.txType === 'contract_call' && unsignedTx) {
     return (
       <ContractCallRequest
         request={payload}
         unsignedTx={unsignedTx}
         funcMetaData={funcMetaData}
         coinsMetaData={coinsMetaData}
+        tabId={Number(tabId)}
+        requestToken={requestToken}
       />
     );
-  if (payload.txType === 'smart_contract')
+  }
+  if (payload.txType === 'smart_contract') {
     return (
       <ContractDeployRequest
         unsignedTx={unsignedTx!}
         codeBody={codeBody!}
         contractName={contractName!}
         sponsored={payload?.sponsored!}
+        tabId={Number(tabId)}
+        requestToken={requestToken}
       />
     );
+  }
 }
 
 export default TransactionRequest;


### PR DESCRIPTION
# PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


If the browser transaction is successful the tx id and rawTx is sent back to the dapps. if the transaction is not successful , the cancel payload is sent. 
