### PR TITLE
Tx Failed Status Fix

### DIFF
--- a/src/app/components/transactions/transactionStatusIcon.tsx
+++ b/src/app/components/transactions/transactionStatusIcon.tsx
@@ -4,6 +4,7 @@ import ReceiveIcon from '@assets/img/transactions/received.svg';
 import SendIcon from '@assets/img/transactions/sent.svg';
 import PendingIcon from '@assets/img/transactions/pending.svg';
 import ContractIcon from '@assets/img/transactions/contract.svg';
+import FailedIcon from '@assets/img/transactions/failed.svg';
 
 interface TransactionStatusIconPros {
   transaction: StxTransactionData | BtcTransactionData;
@@ -14,6 +15,9 @@ function TransactionStatusIcon(props: TransactionStatusIconPros) {
   const { currency, transaction } = props;
   if (currency === 'STX' || currency === 'FT') {
     const tx = transaction as StxTransactionData;
+    if (tx.txStatus === 'abort_by_response' || tx.txStatus === 'abort_by_post_condition') {
+      return <img src={FailedIcon} alt="pending" />;
+    }
     if (tx.txType === 'token_transfer' || tx.tokenType === 'fungible') {
       if (tx.txStatus === 'pending') {
         return <img src={PendingIcon} alt="pending" />;


### PR DESCRIPTION
# PR Type
What kind of change does this PR introduce?
closes #155 

- [x] Bugfix


# What is the current behavior?
- Failed Stx Tx shows with the icon for the transaction types instead of the failure icon 

# What is the new behavior?
- Failed Stx Tx shows with the correct icon