### PR TITLE
Use alternate BRC-20 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.9.0",
       "dependencies": {
         "@react-spring/web": "^9.6.1",
-        "@secretkeylabs/xverse-core": "0.19.0",
+        "@secretkeylabs/xverse-core": "0.20.0",
         "@stacks/connect": "^6.10.2",
         "@stacks/encryption": "4.3.5",
         "@stacks/stacks-blockchain-api-types": "^6.1.1",
@@ -2062,9 +2062,9 @@
       }
     },
     "node_modules/@secretkeylabs/xverse-core": {
-      "version": "0.19.0",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/0.19.0/07452f342839d19d67d97d527d2789024060a771",
-      "integrity": "sha512-0dpi1tHy/xVtWmGeP/xBsPFMtKgLLhTL6EWtusxlKcvTsz9ZE+rF3ZE6+70ykUhPBybPg4fRUJOC8WH+RCB0oQ==",
+      "version": "0.20.0",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/0.20.0/a6de450e0096e18aa17cd863cfddea8ec71d13fe",
+      "integrity": "sha512-QiywUnpwX4jvulHX8fxiyNu+xTDkcgwYTsWdz7e5P5OCQ/YZjD03dWF9fZbrKl3fy6N6k/k+AV9pYzyRaF8K1A==",
       "license": "ISC",
       "dependencies": {
         "@noble/secp256k1": "^1.7.1",
@@ -18653,9 +18653,9 @@
       }
     },
     "@secretkeylabs/xverse-core": {
-      "version": "0.19.0",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/0.19.0/07452f342839d19d67d97d527d2789024060a771",
-      "integrity": "sha512-0dpi1tHy/xVtWmGeP/xBsPFMtKgLLhTL6EWtusxlKcvTsz9ZE+rF3ZE6+70ykUhPBybPg4fRUJOC8WH+RCB0oQ==",
+      "version": "0.20.0",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/0.20.0/a6de450e0096e18aa17cd863cfddea8ec71d13fe",
+      "integrity": "sha512-QiywUnpwX4jvulHX8fxiyNu+xTDkcgwYTsWdz7e5P5OCQ/YZjD03dWF9fZbrKl3fy6N6k/k+AV9pYzyRaF8K1A==",
       "requires": {
         "@noble/secp256k1": "^1.7.1",
         "@scure/base": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@react-spring/web": "^9.6.1",
-    "@secretkeylabs/xverse-core": "0.19.0",
+    "@secretkeylabs/xverse-core": "0.20.0",
     "@stacks/connect": "^6.10.2",
     "@stacks/encryption": "4.3.5",
     "@stacks/stacks-blockchain-api-types": "^6.1.1",


### PR DESCRIPTION
# PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


# What is the current behavior?
BRC-20 API is broken


# What is the new behavior?
Update xverse-core and use api.xverse.app for BRC-20 data

# Screenshot / Video