### PR TITLE
fix: reset Copied text back to default value after a timeout

### DIFF
--- a/src/app/components/accountRow/index.tsx
+++ b/src/app/components/accountRow/index.tsx
@@ -9,7 +9,7 @@ import BarLoader from '@components/barLoader';
 import Copy from '@assets/img/Copy.svg';
 import { LoaderSize } from '@utils/constants';
 import { Account } from '@secretkeylabs/xverse-core';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { ChangeShowBtcReceiveAlertAction } from '@stores/wallet/actions/actionCreators';
 import useWalletSelector from '@hooks/useWalletSelector';
@@ -153,13 +153,12 @@ function AccountRow({
   const [onStxCopied, setOnStxCopied] = useState(false);
   const [onBtcCopied, setOnBtcCopied] = useState(false);
   const dispatch = useDispatch();
-  let btcCopiedTooltipTimeout, stxCopiedTooltipTimeout;
+  const btcCopiedTooltipTimeoutRef = useRef<NodeJS.Timeout | undefined>();
+  const stxCopiedTooltipTimeoutRef = useRef<NodeJS.Timeout | undefined>();
 
-  useEffect(() => {
-    return () => {
-      clearTimeout(btcCopiedTooltipTimeout);
-      clearTimeout(stxCopiedTooltipTimeout);
-    };
+  useEffect(() => () => {
+    clearTimeout(btcCopiedTooltipTimeoutRef.current);
+    clearTimeout(stxCopiedTooltipTimeoutRef.current);
   }, []);
 
   function getName() {
@@ -171,7 +170,7 @@ function AccountRow({
     setOnBtcCopied(true);
     setOnStxCopied(false);
     // set 'Copied' text back to 'Bitcoin address' after 3 seconds
-    btcCopiedTooltipTimeout = setTimeout(() => setOnBtcCopied(false), 3000);
+    btcCopiedTooltipTimeoutRef.current = setTimeout(() => setOnBtcCopied(false), 3000);
     if (showBtcReceiveAlert !== null) {
       dispatch(ChangeShowBtcReceiveAlertAction(true));
     }
@@ -182,7 +181,7 @@ function AccountRow({
     setOnStxCopied(true);
     setOnBtcCopied(false);
     // set 'Copied' text back to 'Stacks address' after 3 seconds
-    stxCopiedTooltipTimeout = setTimeout(() => setOnStxCopied(false), 3000);
+    stxCopiedTooltipTimeoutRef.current = setTimeout(() => setOnStxCopied(false), 3000);
   };
 
   const onRowClick = () => {

--- a/src/app/components/accountRow/index.tsx
+++ b/src/app/components/accountRow/index.tsx
@@ -162,13 +162,19 @@ function AccountRow({
     navigator.clipboard.writeText(account?.btcAddress!);
     setOnBtcCopied(true);
     setOnStxCopied(false);
-    if (showBtcReceiveAlert !== null) { dispatch(ChangeShowBtcReceiveAlertAction(true)); }
+    // set 'Copied' text back to 'Bitcoin address' after 3 seconds
+    setTimeout(() => setOnBtcCopied(false), 3000);
+    if (showBtcReceiveAlert !== null) {
+      dispatch(ChangeShowBtcReceiveAlertAction(true));
+    }
   };
 
   const handleOnStxAddressClick = () => {
     navigator.clipboard.writeText(account?.stxAddress!);
     setOnStxCopied(true);
     setOnBtcCopied(false);
+    // set 'Copied' text back to 'Stacks address' after 3 seconds
+    setTimeout(() => setOnStxCopied(false), 3000);
   };
 
   const onRowClick = () => {

--- a/src/app/components/accountRow/index.tsx
+++ b/src/app/components/accountRow/index.tsx
@@ -9,7 +9,7 @@ import BarLoader from '@components/barLoader';
 import Copy from '@assets/img/Copy.svg';
 import { LoaderSize } from '@utils/constants';
 import { Account } from '@secretkeylabs/xverse-core';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { ChangeShowBtcReceiveAlertAction } from '@stores/wallet/actions/actionCreators';
 import useWalletSelector from '@hooks/useWalletSelector';
@@ -153,6 +153,14 @@ function AccountRow({
   const [onStxCopied, setOnStxCopied] = useState(false);
   const [onBtcCopied, setOnBtcCopied] = useState(false);
   const dispatch = useDispatch();
+  let btcCopiedTooltipTimeout, stxCopiedTooltipTimeout;
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(btcCopiedTooltipTimeout);
+      clearTimeout(stxCopiedTooltipTimeout);
+    };
+  }, []);
 
   function getName() {
     return account?.bnsName ?? `${t('ACCOUNT_NAME')} ${`${(account?.id ?? 0) + 1}`}`;
@@ -163,7 +171,7 @@ function AccountRow({
     setOnBtcCopied(true);
     setOnStxCopied(false);
     // set 'Copied' text back to 'Bitcoin address' after 3 seconds
-    setTimeout(() => setOnBtcCopied(false), 3000);
+    btcCopiedTooltipTimeout = setTimeout(() => setOnBtcCopied(false), 3000);
     if (showBtcReceiveAlert !== null) {
       dispatch(ChangeShowBtcReceiveAlertAction(true));
     }
@@ -174,7 +182,7 @@ function AccountRow({
     setOnStxCopied(true);
     setOnBtcCopied(false);
     // set 'Copied' text back to 'Stacks address' after 3 seconds
-    setTimeout(() => setOnStxCopied(false), 3000);
+    stxCopiedTooltipTimeout = setTimeout(() => setOnStxCopied(false), 3000);
   };
 
   const onRowClick = () => {


### PR DESCRIPTION
# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [x] Other... Please describe:

Whenever Stacks or Bitcoin address is copied it shows Copied tooltip text. That text never gets reset. This aims to reset the text back to it's default value after a timeout

# What is the current behaviour?
When Stacks or Bitcoin address is copied it's tooltip shows Copied indefinitely


# What is the new behaviour?
As commonly observed across other applications where text gets reset, similarly reset the `Copied` text back to default value after 3 seconds

# Screenshot / Video