### PR TITLE
Fix crashes on recover asset flow

### DIFF
--- a/src/app/screens/confirmBtcTransaction/index.tsx
+++ b/src/app/screens/confirmBtcTransaction/index.tsx
@@ -55,7 +55,9 @@ function ConfirmBtcTransaction() {
   );
 
   const onClick = () => {
-    navigate('/recover-ordinals');
+    navigate('/recover-ordinals', {
+      state: { isRestoreFundFlow: true },
+    });
   };
 
   const onContinueButtonClick = () => {

--- a/src/app/screens/restoreFunds/restoreBtc/index.tsx
+++ b/src/app/screens/restoreFunds/restoreBtc/index.tsx
@@ -86,7 +86,7 @@ function RestoreBtc() {
 
   const { data: ordinalsFee } = useQuery({
     queryKey: [`getFee-${ordinalsAddress}`],
-    queryFn: () => getBtcFeesForNonOrdinalBtcSend(btcAddress, unspentUtxos, ordinalsAddress, 'Mainnet'),
+    queryFn: () => getBtcFeesForNonOrdinalBtcSend(btcAddress, unspentUtxos, ordinalsAddress, network.type),
   });
 
   const {
@@ -132,6 +132,7 @@ function RestoreBtc() {
 
   useEffect(() => {
     if (signedNonOrdinalBtcSend) {
+      console.log(ordinalsFee)
       navigate('/confirm-btc-tx', {
         state: {
           signedTxHex: signedNonOrdinalBtcSend.signedTx,

--- a/src/app/screens/restoreFunds/restoreBtc/index.tsx
+++ b/src/app/screens/restoreFunds/restoreBtc/index.tsx
@@ -132,7 +132,6 @@ function RestoreBtc() {
 
   useEffect(() => {
     if (signedNonOrdinalBtcSend) {
-      console.log(ordinalsFee)
       navigate('/confirm-btc-tx', {
         state: {
           signedTxHex: signedNonOrdinalBtcSend.signedTx,

--- a/src/app/screens/restoreFunds/restoreOrdinals/index.tsx
+++ b/src/app/screens/restoreFunds/restoreOrdinals/index.tsx
@@ -1,7 +1,7 @@
 import TopRow from '@components/topRow';
 import useWalletSelector from '@hooks/useWalletSelector';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import ActionButton from '@components/button';
 import BottomTabBar from '@components/tabBar';
@@ -51,9 +51,12 @@ function RestoreOrdinals() {
   const navigate = useNavigate();
   const { ordinals } = useOrdinalsByAddress(btcAddress);
   const [error, setError] = useState('');
-
+  const location = useLocation();
+  const isRestoreFundFlow = location.state?.isRestoreFundFlow;
   const handleOnCancelClick = () => {
-    navigate(-1);
+    if (isRestoreFundFlow) {
+      navigate('/send-btc');
+    } else { navigate(-1); }
   };
 
   return (


### PR DESCRIPTION
# PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


# What is the current behavior?
Currently the extension crashes when user tried to recover their BTC from ordinals address. On mainnet it works fine. 
Issue link for reference: https://linear.app/xverseapp/issue/ENG-2187/app-crashes-on-testnet-when-recovering-btc

On the recover ordinals flow, there is a crash when the user goes back from recover ordinals screen to the btc send flow.
Issue link for reference: https://linear.app/xverseapp/issue/ENG-2196/extension-pop-up-would-crash-when-using-the-go-back-arrow-in-the

# What is the new behavior?
Both crashes are fixed

# Screenshot / Video


https://github.com/secretkeylabs/xverse-web-extension/assets/88320460/81de9ad8-e180-47fb-8de0-090b20d9327c


https://github.com/secretkeylabs/xverse-web-extension/assets/88320460/ebf2b2a8-ffcb-43f6-a11b-29f1e9b4edd2



