### PR TITLE
restore-ordinal-showing-wrong-ordinal

### DIFF
--- a/src/app/screens/ordinalDetail/index.tsx
+++ b/src/app/screens/ordinalDetail/index.tsx
@@ -284,6 +284,7 @@ function OrdinalDetailScreen() {
         setNotSupportedOrdinal(false);
       } else setNotSupportedOrdinal(true);
     }
+    return () => setSelectedOrdinalDetails(null);
   }, [selectedOrdinal?.content_type]);
 
   useEffect(() => {
@@ -295,7 +296,6 @@ function OrdinalDetailScreen() {
   }, [textContent]);
 
   const handleBackButtonClick = () => {
-    setSelectedOrdinalDetails(null);
     navigate('/nft-dashboard');
   };
 

--- a/src/app/screens/restoreFunds/restoreOrdinals/oridnalRow.tsx
+++ b/src/app/screens/restoreFunds/restoreOrdinals/oridnalRow.tsx
@@ -1,4 +1,5 @@
 import useInscriptionDetails from '@hooks/queries/ordinals/useInscriptionDetails';
+import useOrdinalDataReducer from '@hooks/stores/useOrdinalReducer';
 import useWalletSelector from '@hooks/useWalletSelector';
 import OrdinalImage from '@screens/ordinals/ordinalImage';
 import {
@@ -79,6 +80,7 @@ function OrdinalRow({
   const {
     network, ordinalsAddress, btcAddress, selectedAccount, seedPhrase, btcFiatRate,
   } = useWalletSelector();
+  const { setSelectedOrdinalDetails } = useOrdinalDataReducer();
   const navigate = useNavigate();
   const ordinalData = useInscriptionDetails(ordinal.id);
 
@@ -100,6 +102,7 @@ function OrdinalRow({
   });
 
   useEffect(() => {
+    setSelectedOrdinalDetails(ordinalData?.data!);
     if (signedTx) {
       navigate(`/confirm-ordinal-tx/${ordinal.id}`, {
         state: {


### PR DESCRIPTION
# PR Type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


# What is the current behavior?

when viewing and ordinal and exiting the details page without pressing the back button (clicking the bottom bar) the selected ordinal was being persisted in the store

as a result the wrong ordinals details was shown on the confirm tx screen for ordinal recovery

# What is the new behavior?

- selected ordinal gets cleared whenever the details screen gets unmounted
- the correct ordinal details is being set before confirming a recovery
