### PR TITLE
Fix PSBT signing testnet output address showing as mainnet

### DIFF
--- a/src/app/screens/signPsbtRequest/index.tsx
+++ b/src/app/screens/signPsbtRequest/index.tsx
@@ -85,7 +85,7 @@ function SignPsbtRequest() {
 
   const handlePsbtParsing = useCallback(() => {
     try {
-      return parsePsbt(selectedAccount!, payload.inputsToSign, payload.psbtBase64);
+      return parsePsbt(selectedAccount!, payload.inputsToSign, payload.psbtBase64, network.type);
     } catch (err) {
       return '';
     }


### PR DESCRIPTION
# PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


# What is the current behavior?
When creating a PSBT signing request, the network is not passed to the PSBT parser. This results in testnet addresses in the outputs being parsed and displayed as mainnet addresses. And throws off the BTC amount transferred calculation because the user's own address is not recognized.

This bug only appears when in testnet mode.

# What is the new behavior?
Network is properly passed and addresses will display for the correct network.


# Screenshot / Video
Before:
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/29081231/04f8c669-f208-4e4f-882b-ccac6d9ce4d7)


After:
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/29081231/26d585e6-1944-4827-97ca-1364ca51f178)
