### PR TITLE
fix: fixes deregister listener bug

### DIFF
--- a/src/app/hooks/useOnTabClosed.ts
+++ b/src/app/hooks/useOnTabClosed.ts
@@ -2,10 +2,7 @@ import { InternalMethods } from '@common/types/message-types';
 import { BackgroundMessages } from '@common/types/messages';
 import { useEffect } from 'react';
 
-export default function useOnOriginTabClose(
-  tabId: number,
-  handler: () => void,
-) {
+export default function useOnOriginTabClose(tabId: number, handler: () => void) {
   useEffect(() => {
     const messageHandler = (message: BackgroundMessages) => {
       if (message.method !== InternalMethods.OriginatingTabClosed) return;
@@ -16,6 +13,6 @@ export default function useOnOriginTabClose(
 
     chrome.runtime.onMessage.addListener(messageHandler);
 
-    return () => chrome.runtime.onMessage.removeListener(handler);
+    return () => chrome.runtime.onMessage.removeListener(messageHandler);
   }, []);
 }


### PR DESCRIPTION
Fixes a reference error for deregistering a listener

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix

# What is the current behavior?
(Optional) Resolved: 
I'm not sure how this will affect the app but we are deregistering a listener that we didn't register in the first place. It could result in a listener lingering in the background and resources not being closed as expected, but I have the feeling users won't really notice it.

# What is the new behavior?
We deregister the tab close listener correctly.
