### PR TITLE
feat: change onboarding flow

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,13 @@
     "browser": true,
     "es2021": true
   },
-  "extends": ["plugin:react/recommended", "airbnb", "airbnb-typescript", "airbnb/hooks"],
+  "extends": [
+    "plugin:react/recommended",
+    "airbnb",
+    "airbnb-typescript",
+    "airbnb/hooks",
+    "prettier"
+  ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaFeatures": {
@@ -13,21 +19,33 @@
     "sourceType": "module",
     "project": "./tsconfig.json"
   },
-  "plugins": ["react", "prettier", "eslint-plugin-no-inline-styles"],
+  "plugins": [
+    "react",
+    "prettier",
+    "eslint-plugin-no-inline-styles"
+  ],
   "rules": {
     "no-inline-styles/no-inline-styles": 2,
     "react/react-in-jsx-scope": "off",
-    "no-param-reassign":"off",
-    "react/require-default-props":"off",
-    "consistent-return":"off",
-    "max-len":"off",
-    "react-hooks/exhaustive-deps":"off"
+    "no-param-reassign": "off",
+    "react/require-default-props": "off",
+    "consistent-return": "off",
+    "max-len": "off",
+    "react-hooks/exhaustive-deps": "off"
   },
   "settings": {
     "import/resolver": {
       "node": {
-        "extensions": [".js", ".jsx", ".ts", ".tsx"],
-        "moduleDirectory": ["node_modules", "src/"]
+        "extensions": [
+          ".js",
+          ".jsx",
+          ".ts",
+          ".tsx"
+        ],
+        "moduleDirectory": [
+          "node_modules",
+          "src/"
+        ]
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
         "eslint": "8.22.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-airbnb-typescript": "^17.0.0",
+        "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-jsx-a11y": "^6.6.1",
         "eslint-plugin-no-inline-styles": "^1.0.5",
@@ -8066,6 +8067,18 @@
         "@typescript-eslint/parser": "^5.0.0",
         "eslint": "^7.32.0 || ^8.2.0",
         "eslint-plugin-import": "^2.25.3"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -23915,6 +23928,13 @@
       "requires": {
         "eslint-config-airbnb-base": "^15.0.0"
       }
+    },
+    "eslint-config-prettier": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.11.6",
       "dependencies": {
         "@react-spring/web": "^9.6.1",
-        "@secretkeylabs/xverse-core": "^0.23.1",
+        "@secretkeylabs/xverse-core": "^1.0.0",
         "@stacks/connect": "^6.10.2",
         "@stacks/encryption": "4.3.5",
         "@stacks/stacks-blockchain-api-types": "^6.1.1",
@@ -2079,9 +2079,9 @@
       }
     },
     "node_modules/@secretkeylabs/xverse-core": {
-      "version": "0.23.2",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/0.23.2/05f799515eb641ef0ffd3e260342cddb98ce5ca9",
-      "integrity": "sha512-rBbX645acd511c3jGb7rNrdgX0c/ihrbJKl5wV3qkCwCCfdWofcv0Fjs/mvAnNgzvZlMVG+8lBWM22rmjxkMWQ==",
+      "version": "1.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.0.0/519e8454c68a5a3555024602406444757bbb1fd7",
+      "integrity": "sha512-wbtPcTsJ+d0SA3rcPMg0dBmR5bw8kcSjqVDSepGWIQoCpRjbRP6x+Wcd4sdnEmqTO9bulhekAwG1AbWSQxhs4A==",
       "license": "ISC",
       "dependencies": {
         "@noble/secp256k1": "^1.7.1",
@@ -18844,9 +18844,9 @@
       }
     },
     "@secretkeylabs/xverse-core": {
-      "version": "0.23.2",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/0.23.2/05f799515eb641ef0ffd3e260342cddb98ce5ca9",
-      "integrity": "sha512-rBbX645acd511c3jGb7rNrdgX0c/ihrbJKl5wV3qkCwCCfdWofcv0Fjs/mvAnNgzvZlMVG+8lBWM22rmjxkMWQ==",
+      "version": "1.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.0.0/519e8454c68a5a3555024602406444757bbb1fd7",
+      "integrity": "sha512-wbtPcTsJ+d0SA3rcPMg0dBmR5bw8kcSjqVDSepGWIQoCpRjbRP6x+Wcd4sdnEmqTO9bulhekAwG1AbWSQxhs4A==",
       "requires": {
         "@noble/secp256k1": "^1.7.1",
         "@scure/base": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "eslint": "8.22.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-typescript": "^17.0.0",
+    "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-no-inline-styles": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@react-spring/web": "^9.6.1",
-    "@secretkeylabs/xverse-core": "^0.23.1",
+    "@secretkeylabs/xverse-core": "^1.0.0",
     "@stacks/connect": "^6.10.2",
     "@stacks/encryption": "4.3.5",
     "@stacks/stacks-blockchain-api-types": "^6.1.1",

--- a/src/app/components/guards/onboarding/WalletExistsContext.ts
+++ b/src/app/components/guards/onboarding/WalletExistsContext.ts
@@ -1,0 +1,12 @@
+import { createContext, useContext } from 'react';
+
+export type WalletExistsContextProps = {
+  disableWalletExistsGuard?: () => void;
+};
+
+export const WalletExistsContext = createContext<WalletExistsContextProps>({});
+
+export const useWalletExistsContext = (): WalletExistsContextProps => {
+  const context = useContext(WalletExistsContext);
+  return context;
+};

--- a/src/app/components/guards/onboarding/index.tsx
+++ b/src/app/components/guards/onboarding/index.tsx
@@ -1,32 +1,30 @@
+import { useMemo, useState } from 'react';
+import { Navigate } from 'react-router-dom';
+
 import useHasStateRehydrated from '@hooks/stores/useHasRehydrated';
 import useWalletSelector from '@hooks/useWalletSelector';
+
 import {
-  createContext,
-  useContext,
-  useMemo,
-  useState,
-} from 'react';
-import { Navigate } from 'react-router-dom';
+  WalletExistsContext,
+  WalletExistsContextProps,
+  useWalletExistsContext,
+} from './WalletExistsContext';
+import useOnboardingSingleton from './useOnboardingSingleton';
 
 interface WalletExistsGuardProps {
   children: React.ReactElement;
 }
 
-type WalletExistsGuardContext = {
-  disableWalletExistsGuard?: () => void;
-};
+/**
+ * This guard is used to redirect the user to the wallet exists page if they have a wallet and ensures
+ * that only 1 onboarding workflow tab exists at a time (via the useOnboardingSingleton hook).
+ */
+function OnboardingGuard({ children }: WalletExistsGuardProps): React.ReactElement {
+  useOnboardingSingleton();
 
-const WalletExistsContext = createContext<WalletExistsGuardContext>({});
-
-export const useWalletExistsGuardContext = (): WalletExistsGuardContext => {
-  const context = useContext(WalletExistsContext);
-  return context;
-};
-
-function WalletExistsGuard({ children }: WalletExistsGuardProps): React.ReactElement {
   const [walletExistsGuardEnabled, setWalletExistsGuardEnabled] = useState(true);
 
-  const contextValue: WalletExistsGuardContext = useMemo(
+  const contextValue: WalletExistsContextProps = useMemo(
     () => ({
       disableWalletExistsGuard: () => setWalletExistsGuardEnabled(false),
     }),
@@ -45,4 +43,6 @@ function WalletExistsGuard({ children }: WalletExistsGuardProps): React.ReactEle
   );
 }
 
-export default WalletExistsGuard;
+export default OnboardingGuard;
+
+export { useWalletExistsContext };

--- a/src/app/components/guards/onboarding/useOnboardingSingleton.ts
+++ b/src/app/components/guards/onboarding/useOnboardingSingleton.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+const ONBOARDING_CHANNEL_NAME = 'onboarding';
+const ONBOARDING_PING = 'pingOnboarding';
+
+/**
+ * This hook is used to ensure that only one onboarding window is open at a time.
+ */
+const useOnboardingSingleton = (): void => {
+  useEffect(() => {
+    const broadcastChannel = new BroadcastChannel(ONBOARDING_CHANNEL_NAME);
+
+    broadcastChannel.onmessage = (message) => {
+      if (message.data !== ONBOARDING_PING) {
+        return;
+      }
+
+      broadcastChannel.close();
+      window.close();
+    };
+
+    broadcastChannel.postMessage(ONBOARDING_PING);
+
+    return () => {
+      broadcastChannel.close();
+    };
+  }, []);
+};
+
+export default useOnboardingSingleton;

--- a/src/app/components/seedPhraseView/index.tsx
+++ b/src/app/components/seedPhraseView/index.tsx
@@ -1,6 +1,6 @@
+import Eye from '@assets/img/createPassword/Eye.svg';
 import { useMemo } from 'react';
 import styled from 'styled-components';
-import Eye from '@assets/img/createPassword/Eye.svg';
 import SeedPhraseWord from './word';
 
 interface SeedPhraseViewProps {
@@ -75,7 +75,8 @@ export default function SeedphraseView(props: SeedPhraseViewProps) {
       <OuterSeedContainer>
         <SeedContainer isVisible={isVisible}>
           {seedPhraseWords.map((word, index) => (
-            <SeedPhraseWord index={index} word={word} />
+            // eslint-disable-next-line react/no-array-index-key
+            <SeedPhraseWord key={index} index={index} word={word} />
           ))}
         </SeedContainer>
       </OuterSeedContainer>

--- a/src/app/routes/index.tsx
+++ b/src/app/routes/index.tsx
@@ -1,6 +1,6 @@
 import ExtendedScreenContainer from '@components/extendedScreenContainer';
 import AuthGuard from '@components/guards/auth';
-import WalletExistsGuard from '@components/guards/walletExists';
+import OnboardingGuard from '@components/guards/onboarding';
 import ScreenContainer from '@components/screenContainer';
 import AccountList from '@screens/accountList';
 import AuthenticationRequest from '@screens/authenticationRequest';
@@ -24,7 +24,6 @@ import Landing from '@screens/landing';
 import LegalLinks from '@screens/legalLinks';
 import Login from '@screens/login';
 import ManageTokens from '@screens/manageTokens';
-import MigrationConfirmation from '@screens/migrationConfirmation';
 import NftDashboard from '@screens/nftDashboard';
 import NftDetailScreen from '@screens/nftDetail';
 import Onboarding from '@screens/onboarding';
@@ -66,14 +65,10 @@ const router = createHashRouter([
       {
         path: 'onboarding',
         element: (
-          <WalletExistsGuard>
+          <OnboardingGuard>
             <Onboarding />
-          </WalletExistsGuard>
+          </OnboardingGuard>
         ),
-      },
-      {
-        path: 'migration-confirmation',
-        element: <MigrationConfirmation />,
       },
       {
         index: true,
@@ -86,9 +81,9 @@ const router = createHashRouter([
       {
         path: 'legal',
         element: (
-          <WalletExistsGuard>
+          <OnboardingGuard>
             <LegalLinks />
-          </WalletExistsGuard>
+          </OnboardingGuard>
         ),
       },
       {
@@ -130,17 +125,17 @@ const router = createHashRouter([
       {
         path: 'backup',
         element: (
-          <WalletExistsGuard>
+          <OnboardingGuard>
             <BackupWallet />
-          </WalletExistsGuard>
+          </OnboardingGuard>
         ),
       },
       {
         path: 'create-password',
         element: (
-          <WalletExistsGuard>
+          <OnboardingGuard>
             <CreatePassword />
-          </WalletExistsGuard>
+          </OnboardingGuard>
         ),
       },
       {
@@ -190,9 +185,9 @@ const router = createHashRouter([
       {
         path: 'restoreWallet',
         element: (
-          <WalletExistsGuard>
+          <OnboardingGuard>
             <RestoreWallet />
-          </WalletExistsGuard>
+          </OnboardingGuard>
         ),
       },
       {
@@ -202,9 +197,9 @@ const router = createHashRouter([
       {
         path: 'backupWalletSteps',
         element: (
-          <WalletExistsGuard>
+          <OnboardingGuard>
             <BackupWalletSteps />
-          </WalletExistsGuard>
+          </OnboardingGuard>
         ),
       },
       {

--- a/src/app/routes/index.tsx
+++ b/src/app/routes/index.tsx
@@ -24,10 +24,10 @@ import Landing from '@screens/landing';
 import LegalLinks from '@screens/legalLinks';
 import Login from '@screens/login';
 import ManageTokens from '@screens/manageTokens';
+import MigrationConfirmation from '@screens/migrationConfirmation';
 import NftDashboard from '@screens/nftDashboard';
 import NftDetailScreen from '@screens/nftDetail';
 import Onboarding from '@screens/onboarding';
-import MigrationConfirmation from '@screens/migrationConfirmation';
 import OrdinalDetailScreen from '@screens/ordinalDetail';
 import Receive from '@screens/receive';
 import RestoreFunds from '@screens/restoreFunds';
@@ -73,9 +73,7 @@ const router = createHashRouter([
       },
       {
         path: 'migration-confirmation',
-        element: (
-          <MigrationConfirmation />
-        ),
+        element: <MigrationConfirmation />,
       },
       {
         index: true,
@@ -87,7 +85,11 @@ const router = createHashRouter([
       },
       {
         path: 'legal',
-        element: <LegalLinks />,
+        element: (
+          <WalletExistsGuard>
+            <LegalLinks />
+          </WalletExistsGuard>
+        ),
       },
       {
         path: 'manage-tokens',

--- a/src/app/screens/backupWallet/index.tsx
+++ b/src/app/screens/backupWallet/index.tsx
@@ -1,8 +1,12 @@
 import backup from '@assets/img/backupWallet/backup.svg';
-import styled from 'styled-components';
+import ActionButton from '@components/button';
+import useWalletReducer from '@hooks/useWalletReducer';
+import useWalletSelector from '@hooks/useWalletSelector';
+import * as bip39 from 'bip39';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import ActionButton from '@components/button';
+import styled from 'styled-components';
 
 const Container = styled.div((props) => ({
   flex: 1,
@@ -54,6 +58,15 @@ const TransparentButtonContainer = styled.div((props) => ({
 function BackupWallet(): JSX.Element {
   const { t } = useTranslation('translation', { keyPrefix: 'BACKUP_WALLET_SCREEN' });
   const navigate = useNavigate();
+  const { seedPhrase } = useWalletSelector();
+  const { storeSeedPhrase } = useWalletReducer();
+
+  useEffect(() => {
+    if (!seedPhrase) {
+      const newSeedPhrase = bip39.generateMnemonic();
+      storeSeedPhrase(newSeedPhrase);
+    }
+  }, []);
 
   const handleBackup = () => {
     navigate('/backupWalletSteps');

--- a/src/app/screens/backupWallet/index.tsx
+++ b/src/app/screens/backupWallet/index.tsx
@@ -2,7 +2,7 @@ import backup from '@assets/img/backupWallet/backup.svg';
 import ActionButton from '@components/button';
 import useWalletReducer from '@hooks/useWalletReducer';
 import useWalletSelector from '@hooks/useWalletSelector';
-import * as bip39 from 'bip39';
+import { generateMnemonic } from '@secretkeylabs/xverse-core/wallet';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -63,7 +63,7 @@ function BackupWallet(): JSX.Element {
 
   useEffect(() => {
     if (!seedPhrase) {
-      const newSeedPhrase = bip39.generateMnemonic();
+      const newSeedPhrase = generateMnemonic();
       storeSeedPhrase(newSeedPhrase);
     }
   }, []);

--- a/src/app/screens/backupWalletSteps/index.tsx
+++ b/src/app/screens/backupWalletSteps/index.tsx
@@ -1,4 +1,4 @@
-import { useWalletExistsGuardContext } from '@components/guards/walletExists';
+import { useWalletExistsContext } from '@components/guards/onboarding';
 import PasswordInput from '@components/passwordInput';
 import Steps from '@components/steps';
 import useWalletReducer from '@hooks/useWalletReducer';
@@ -45,7 +45,7 @@ export default function BackupWalletSteps(): JSX.Element {
     ...state.walletState,
   }));
   const { createWallet } = useWalletReducer();
-  const { disableWalletExistsGuard } = useWalletExistsGuardContext();
+  const { disableWalletExistsGuard } = useWalletExistsContext();
 
   const handleSeedCheckContinue = () => {
     setCurrentActiveIndex(1);

--- a/src/app/screens/backupWalletSteps/index.tsx
+++ b/src/app/screens/backupWalletSteps/index.tsx
@@ -1,5 +1,7 @@
+import { useWalletExistsGuardContext } from '@components/guards/walletExists';
 import PasswordInput from '@components/passwordInput';
 import Steps from '@components/steps';
+import useWalletReducer from '@hooks/useWalletReducer';
 import { StoreState } from '@stores/index';
 import { storeEncryptedSeedAction } from '@stores/wallet/actions/actionCreators';
 import { encryptSeedPhrase } from '@utils/encryptionUtils';
@@ -42,6 +44,8 @@ export default function BackupWalletSteps(): JSX.Element {
   const { seedPhrase } = useSelector((state: StoreState) => ({
     ...state.walletState,
   }));
+  const { createWallet } = useWalletReducer();
+  const { disableWalletExistsGuard } = useWalletExistsGuardContext();
 
   const handleSeedCheckContinue = () => {
     setCurrentActiveIndex(1);
@@ -70,8 +74,10 @@ export default function BackupWalletSteps(): JSX.Element {
   const handleConfirmPasswordContinue = async () => {
     try {
       if (confirmPassword === password) {
+        disableWalletExistsGuard?.();
         const encryptedSeed = await encryptSeedPhrase(seedPhrase, password);
         dispatch(storeEncryptedSeedAction(encryptedSeed));
+        await createWallet(seedPhrase);
         navigate('/wallet-success/create');
       }
     } catch (err) {

--- a/src/app/screens/createPassword/index.tsx
+++ b/src/app/screens/createPassword/index.tsx
@@ -1,4 +1,4 @@
-import { useWalletExistsGuardContext } from '@components/guards/walletExists';
+import { useWalletExistsContext } from '@components/guards/onboarding';
 import PasswordInput from '@components/passwordInput';
 import useWalletReducer from '@hooks/useWalletReducer';
 import { StoreState } from '@stores/index';
@@ -56,7 +56,7 @@ function CreatePassword(): JSX.Element {
   }));
   const { t } = useTranslation('translation', { keyPrefix: 'CREATE_PASSWORD_SCREEN' });
   const { createWallet } = useWalletReducer();
-  const { disableWalletExistsGuard } = useWalletExistsGuardContext();
+  const { disableWalletExistsGuard } = useWalletExistsContext();
 
   const handleContinuePasswordCreation = () => {
     setCurrentStepIndex(1);

--- a/src/app/screens/createPassword/index.tsx
+++ b/src/app/screens/createPassword/index.tsx
@@ -1,5 +1,6 @@
 import { useWalletExistsGuardContext } from '@components/guards/walletExists';
 import PasswordInput from '@components/passwordInput';
+import useWalletReducer from '@hooks/useWalletReducer';
 import { StoreState } from '@stores/index';
 import { storeEncryptedSeedAction } from '@stores/wallet/actions/actionCreators';
 import { encryptSeedPhrase } from '@utils/encryptionUtils';
@@ -54,6 +55,7 @@ function CreatePassword(): JSX.Element {
     ...state.walletState,
   }));
   const { t } = useTranslation('translation', { keyPrefix: 'CREATE_PASSWORD_SCREEN' });
+  const { createWallet } = useWalletReducer();
   const { disableWalletExistsGuard } = useWalletExistsGuardContext();
 
   const handleContinuePasswordCreation = () => {
@@ -66,6 +68,7 @@ function CreatePassword(): JSX.Element {
 
       const encryptedSeed = await encryptSeedPhrase(seedPhrase, password);
       dispatch(storeEncryptedSeedAction(encryptedSeed));
+      await createWallet(seedPhrase);
 
       navigate('/wallet-success/create');
     } else {

--- a/src/app/screens/landing/index.tsx
+++ b/src/app/screens/landing/index.tsx
@@ -109,15 +109,15 @@ function Landing(): JSX.Element {
     delay: 100,
   });
 
-  const openInNewTab = async (isRestore = false) => {
+  const startWalletOnboarding = async (isRestore = false) => {
     const params = isRestore ? '?restore=true' : '';
     await chrome.tabs.create({
       url: chrome.runtime.getURL(`options.html#/onboarding${params}`),
     });
   };
 
-  const handlePressCreate = async () => openInNewTab();
-  const handlePressRestore = async () => openInNewTab(true);
+  const handlePressCreate = async () => startWalletOnboarding();
+  const handlePressRestore = async () => startWalletOnboarding(true);
 
   return (
     <>

--- a/src/app/screens/landing/index.tsx
+++ b/src/app/screens/landing/index.tsx
@@ -1,8 +1,7 @@
-import styled from 'styled-components';
 import logo from '@assets/img/xverse_logo.svg';
-import { useTranslation } from 'react-i18next';
-import useWalletReducer from '@hooks/useWalletReducer';
 import { animated, useSpring } from '@react-spring/web';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
 
 const ContentContainer = styled(animated.div)({
   position: 'relative',
@@ -98,7 +97,6 @@ const RestoreButton = styled.button((props) => ({
 
 function Landing(): JSX.Element {
   const { t } = useTranslation('translation', { keyPrefix: 'LANDING_SCREEN' });
-  const { createWallet } = useWalletReducer();
   const styles = useSpring({
     from: {
       opacity: 0,
@@ -111,31 +109,16 @@ function Landing(): JSX.Element {
     delay: 100,
   });
 
-  const openInNewTab = async () => {
+  const openInNewTab = async (isRestore = false) => {
+    const params = isRestore ? '?restore=true' : '';
     await chrome.tabs.create({
-      url: chrome.runtime.getURL('options.html#/onboarding'),
+      url: chrome.runtime.getURL(`options.html#/onboarding${params}`),
     });
   };
 
-  const handlePressCreate = async () => {
-    try {
-      await createWallet();
-    } catch (err) {
-      return await Promise.reject(err);
-    } finally {
-      setTimeout(async () => openInNewTab(), 500);
-    }
-  };
+  const handlePressCreate = async () => openInNewTab();
+  const handlePressRestore = async () => openInNewTab(true);
 
-  const handlePressRestore = async () => {
-    try {
-      window.localStorage.setItem('isRestore', 'true');
-      await openInNewTab();
-      return true;
-    } catch (err) {
-      return Promise.reject(err);
-    }
-  };
   return (
     <>
       <AppVersion>Beta</AppVersion>

--- a/src/app/screens/legalLinks/index.tsx
+++ b/src/app/screens/legalLinks/index.tsx
@@ -1,10 +1,10 @@
-import { useTranslation } from 'react-i18next';
-import styled from 'styled-components';
 import LinkIcon from '@assets/img/linkIcon.svg';
-import { useNavigate } from 'react-router-dom';
-import { saveIsTermsAccepted } from '@utils/localStorage';
 import Seperator from '@components/seperator';
 import { PRIVACY_POLICY_LINK, TERMS_LINK } from '@utils/constants';
+import { saveIsTermsAccepted } from '@utils/localStorage';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import styled from 'styled-components';
 
 const Container = styled.div((props) => ({
   flex: 1,
@@ -65,12 +65,12 @@ const AcceptButton = styled.button((props) => ({
 function LegalLinks() {
   const { t } = useTranslation('translation', { keyPrefix: 'LEGAL_SCREEN' });
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
 
   const handleLegalAccept = () => {
     saveIsTermsAccepted(true);
-    const isRestore = localStorage.getItem('isRestore');
+    const isRestore = !!searchParams.get('restore');
     if (isRestore) {
-      localStorage.removeItem('isRestore');
       navigate('/restoreWallet');
     } else {
       navigate('/backup');

--- a/src/app/screens/onboarding/index.tsx
+++ b/src/app/screens/onboarding/index.tsx
@@ -1,14 +1,14 @@
-import { useState } from 'react';
 import onboarding1 from '@assets/img/onboarding/onboarding1.svg';
 import onboarding2 from '@assets/img/onboarding/onboarding2.svg';
 import onboarding3 from '@assets/img/onboarding/onboarding3.png';
-import { useTranslation } from 'react-i18next';
-import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
+import ActionButton from '@components/button';
+import Steps from '@components/steps';
 import { animated, useTransition } from '@react-spring/web';
 import { getIsTermsAccepted, saveHasFinishedOnboarding } from '@utils/localStorage';
-import Steps from '@components/steps';
-import ActionButton from '@components/button';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import styled from 'styled-components';
 
 const Container = styled.div`
   display: flex;
@@ -75,6 +75,7 @@ function Onboarding(): JSX.Element {
       opacity: 1,
     },
   });
+  const [searchParams] = useSearchParams();
 
   const onboardingViews = [
     {
@@ -102,18 +103,19 @@ function Onboarding(): JSX.Element {
   };
 
   const handleSkip = () => {
-    const isRestore = localStorage.getItem('isRestore');
     saveHasFinishedOnboarding(true);
     const isLegalAccepted = getIsTermsAccepted();
+    const isRestore = !!searchParams.get('restore');
+
     if (isLegalAccepted) {
       if (isRestore) {
-        localStorage.removeItem('isRestore');
         navigate('/restoreWallet');
       } else {
         navigate('/backup');
       }
     } else {
-      navigate('/legal');
+      const params = isRestore ? '?restore=true' : '';
+      navigate(`/legal${params}`);
     }
   };
 
@@ -136,10 +138,7 @@ function Onboarding(): JSX.Element {
           </OnBoardingContentContainer>
           {index === onboardingViews.length - 1 ? (
             <OnBoardingActionsContainer>
-              <ActionButton
-                onPress={handleSkip}
-                text={t('ONBOARDING_CONTINUE_BUTTON')}
-              />
+              <ActionButton onPress={handleSkip} text={t('ONBOARDING_CONTINUE_BUTTON')} />
             </OnBoardingActionsContainer>
           ) : (
             <OnBoardingActionsContainer>

--- a/src/app/screens/restoreWallet/index.tsx
+++ b/src/app/screens/restoreWallet/index.tsx
@@ -1,4 +1,4 @@
-import { useWalletExistsGuardContext } from '@components/guards/walletExists';
+import { useWalletExistsContext } from '@components/guards/onboarding';
 import PasswordInput from '@components/passwordInput';
 import Steps from '@components/steps';
 import useWalletReducer from '@hooks/useWalletReducer';
@@ -38,9 +38,10 @@ function RestoreWallet(): JSX.Element {
   const [seedError, setSeedError] = useState<string>('');
   const [error, setError] = useState<string>('');
   const navigate = useNavigate();
-  const { disableWalletExistsGuard } = useWalletExistsGuardContext();
+  const { disableWalletExistsGuard } = useWalletExistsContext();
 
-  const cleanMnemonic = (rawSeed: string): string => rawSeed.replace(/\s\s+/g, ' ').replace(/\n/g, ' ').trim();
+  const cleanMnemonic = (rawSeed: string): string =>
+    rawSeed.replace(/\s\s+/g, ' ').replace(/\n/g, ' ').trim();
 
   const handleNewPasswordBack = () => {
     setCurrentStepIndex(0);

--- a/src/app/screens/settings/settingComponent/index.tsx
+++ b/src/app/screens/settings/settingComponent/index.tsx
@@ -101,7 +101,7 @@ function SettingComponent({
           onColor={theme.colors.purple_main}
           offColor={theme.colors.background.elevation3}
           onChange={toggleFunction}
-          checked={toggleValue!}
+          checked={toggleValue ?? false}
           uncheckedIcon={false}
           checkedIcon={false}
         />

--- a/src/app/stores/index.ts
+++ b/src/app/stores/index.ts
@@ -1,11 +1,12 @@
 /* eslint-disable no-underscore-dangle */
+import * as actions from '@stores/wallet/actions/types';
 import ChromeStorage from '@utils/storage';
 import { applyMiddleware, combineReducers, createStore } from 'redux';
-import { persistReducer, persistStore, PersistConfig } from 'redux-persist';
+import { PersistConfig, persistReducer, persistStore } from 'redux-persist';
 import { createStateSyncMiddleware, initMessageListener } from 'redux-state-sync';
 import NftDataStateReducer from './nftData/reducer';
-import walletReducer from './wallet/reducer';
 import { WalletState } from './wallet/actions/types';
+import walletReducer from './wallet/reducer';
 
 export const storage = new ChromeStorage(chrome.storage.local, chrome.runtime);
 
@@ -40,7 +41,7 @@ const rootStore = (() => {
   const storeMiddleware = [
     createStateSyncMiddleware({
       // We don't want to sync the redux-persist actions
-      blacklist: ['persist/PERSIST', 'persist/REHYDRATE'],
+      blacklist: [actions.UnlockWalletKey, 'persist/PERSIST', 'persist/REHYDRATE'],
     }),
   ];
   const store = createStore(persistedReducer, applyMiddleware(...storeMiddleware));

--- a/src/app/stores/index.ts
+++ b/src/app/stores/index.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-underscore-dangle */
-import * as actions from '@stores/wallet/actions/types';
 import ChromeStorage from '@utils/storage';
 import { applyMiddleware, combineReducers, createStore } from 'redux';
 import { PersistConfig, persistReducer, persistStore } from 'redux-persist';
@@ -41,7 +40,7 @@ const rootStore = (() => {
   const storeMiddleware = [
     createStateSyncMiddleware({
       // We don't want to sync the redux-persist actions
-      blacklist: [actions.UnlockWalletKey, 'persist/PERSIST', 'persist/REHYDRATE'],
+      blacklist: ['persist/PERSIST', 'persist/REHYDRATE'],
     }),
   ];
   const store = createStore(persistedReducer, applyMiddleware(...storeMiddleware));


### PR DESCRIPTION
Onboarding used to get a wallet generated by the popup and it would configure a password to unlock it. This led to a race condition with multiple screens open.

With the update, the flow now creates a seed phrase only and generates and persists the wallet at the end of the flow.

# PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


# What is the current behavior?
The popup would generate a wallet


# What is the new behavior?
The onboarding screen generates everything.