### PR TITLE
fix: manual lock not locking on popup show and hide

### DIFF
--- a/src/app/components/guards/session.tsx
+++ b/src/app/components/guards/session.tsx
@@ -7,7 +7,7 @@ interface SessionGuardProps {
 }
 
 function SessionGuard({ children }: SessionGuardProps): ReactElement | null {
-  const { shouldLock } = useWalletSession();
+  const { shouldLock, setSessionStartTime } = useWalletSession();
   const { lockWallet } = useWalletReducer();
   const [lockTested, setLockTested] = useState(false);
 
@@ -16,6 +16,8 @@ function SessionGuard({ children }: SessionGuardProps): ReactElement | null {
       const sessionEnded = await shouldLock();
       if (sessionEnded) {
         await lockWallet();
+      } else {
+        setSessionStartTime();
       }
       setLockTested(true);
     };

--- a/src/app/components/guards/session.tsx
+++ b/src/app/components/guards/session.tsx
@@ -7,7 +7,7 @@ interface SessionGuardProps {
 }
 
 function SessionGuard({ children }: SessionGuardProps): ReactElement | null {
-  const { shouldLock, clearSessionKey } = useWalletSession();
+  const { shouldLock } = useWalletSession();
   const { lockWallet } = useWalletReducer();
   const [lockTested, setLockTested] = useState(false);
 
@@ -15,8 +15,7 @@ function SessionGuard({ children }: SessionGuardProps): ReactElement | null {
     const tryLock = async () => {
       const sessionEnded = await shouldLock();
       if (sessionEnded) {
-        await clearSessionKey();
-        lockWallet();
+        await lockWallet();
       }
       setLockTested(true);
     };

--- a/src/app/hooks/useWalletReducer.ts
+++ b/src/app/hooks/useWalletReducer.ts
@@ -32,7 +32,7 @@ const useWalletReducer = () => {
   const dispatch = useDispatch();
   const { refetch: refetchStxData } = useStxWalletData();
   const { refetch: refetchBtcData } = useBtcWalletData();
-  const { setSessionStartTime, clearSessionTime } = useWalletSession();
+  const { setSessionStartTime, clearSessionTime, clearSessionKey } = useWalletSession();
 
   const loadActiveAccounts = async (
     secretKey: string,
@@ -103,9 +103,10 @@ const useWalletReducer = () => {
     return decrypted;
   };
 
-  const lockWallet = () => {
+  const lockWallet = async () => {
     dispatch(lockWalletAction());
-    clearSessionTime();
+    await clearSessionTime();
+    await clearSessionKey();
   };
 
   const resetWallet = () => {
@@ -196,12 +197,6 @@ const useWalletReducer = () => {
     dispatch(fetchAccountAction(account, [account]));
     setSessionStartTime();
     localStorage.setItem('migrated', 'true');
-    await sendMessage({
-      method: InternalMethods.ShareInMemoryKeyToBackground,
-      payload: {
-        secretKey: wallet.seedPhrase,
-      },
-    });
   };
 
   const createAccount = async () => {


### PR DESCRIPTION
# PR Type
What kind of change does this PR introduce?
- [x] Bugfix

# What is the current behavior?
If you click on the menu and on "Lock", the popup will show as locked, but if you hide the popup and show it again, it will come up as unlocked.

# What is the new behavior?
On lock, the wallet will lock, regardless of whether you hide and show the popup or not.

# Screenshot / Video
Before fix:
https://github.com/secretkeylabs/xverse-web-extension/assets/3322667/aa5b6684-c34c-4b54-a3ab-cc6109c710f7

