### PR TITLE
fix: don't fire bitcoin and stacks wallet queries when no address

### DIFF
--- a/src/app/hooks/queries/useBtcWalletData.ts
+++ b/src/app/hooks/queries/useBtcWalletData.ts
@@ -1,9 +1,9 @@
-import BigNumber from 'bignumber.js';
-import { useDispatch } from 'react-redux';
-import { useQuery } from '@tanstack/react-query';
+import useBtcClient from '@hooks/useBtcClient';
 import { BtcAddressData } from '@secretkeylabs/xverse-core/types';
 import { SetBtcWalletDataAction } from '@stores/wallet/actions/actionCreators';
-import useBtcClient from '@hooks/useBtcClient';
+import { useQuery } from '@tanstack/react-query';
+import BigNumber from 'bignumber.js';
+import { useDispatch } from 'react-redux';
 import useWalletSelector from '../useWalletSelector';
 
 export const useBtcWalletData = () => {
@@ -12,20 +12,17 @@ export const useBtcWalletData = () => {
   const btcClient = useBtcClient();
 
   const fetchBtcWalletData = async () => {
-    try {
-      const btcData: BtcAddressData = await btcClient.getBalance(btcAddress);
-      const btcBalance = new BigNumber(btcData.finalBalance);
-      dispatch(SetBtcWalletDataAction(btcBalance));
-      return btcData;
-    } catch (error) {
-      return Promise.reject(error);
-    }
+    const btcData: BtcAddressData = await btcClient.getBalance(btcAddress);
+    const btcBalance = new BigNumber(btcData.finalBalance);
+    dispatch(SetBtcWalletDataAction(btcBalance));
+    return btcData;
   };
 
   return useQuery({
     queryKey: [`wallet-data-${btcAddress}`],
     refetchOnWindowFocus: true,
     queryFn: fetchBtcWalletData,
+    enabled: !!btcAddress,
   });
 };
 

--- a/src/app/hooks/queries/useStxWalletData.ts
+++ b/src/app/hooks/queries/useStxWalletData.ts
@@ -1,11 +1,11 @@
-import { useDispatch } from 'react-redux';
-import { useQuery } from '@tanstack/react-query';
-import { StxAddressData } from '@secretkeylabs/xverse-core/types';
 import { fetchStxAddressData } from '@secretkeylabs/xverse-core/api';
-import { PAGINATION_LIMIT } from '@utils/constants';
+import { StxAddressData } from '@secretkeylabs/xverse-core/types';
 import { setStxWalletDataAction } from '@stores/wallet/actions/actionCreators';
-import useWalletSelector from '../useWalletSelector';
+import { useQuery } from '@tanstack/react-query';
+import { PAGINATION_LIMIT } from '@utils/constants';
+import { useDispatch } from 'react-redux';
 import useNetworkSelector from '../useNetwork';
+import useWalletSelector from '../useWalletSelector';
 
 export const useStxWalletData = () => {
   const dispatch = useDispatch();
@@ -13,31 +13,28 @@ export const useStxWalletData = () => {
   const currentNetworkInstance = useNetworkSelector();
 
   const fetchStxWalletData = async (): Promise<StxAddressData> => {
-    try {
-      const stxData: StxAddressData = await fetchStxAddressData(
-        stxAddress,
-        currentNetworkInstance,
-        0,
-        PAGINATION_LIMIT,
-      );
-      dispatch(
-        setStxWalletDataAction(
-          stxData.balance,
-          stxData.availableBalance,
-          stxData.locked,
-          stxData.transactions,
-          stxData.nonce,
-        ),
-      );
-      return stxData;
-    } catch (error) {
-      return Promise.reject(error);
-    }
+    const stxData: StxAddressData = await fetchStxAddressData(
+      stxAddress,
+      currentNetworkInstance,
+      0,
+      PAGINATION_LIMIT,
+    );
+    dispatch(
+      setStxWalletDataAction(
+        stxData.balance,
+        stxData.availableBalance,
+        stxData.locked,
+        stxData.transactions,
+        stxData.nonce,
+      ),
+    );
+    return stxData;
   };
 
   return useQuery({
     queryKey: [`wallet-data-${stxAddress}`],
     queryFn: fetchStxWalletData,
+    enabled: !!stxAddress,
   });
 };
 

--- a/src/app/hooks/useWalletReducer.ts
+++ b/src/app/hooks/useWalletReducer.ts
@@ -196,12 +196,6 @@ const useWalletReducer = () => {
     dispatch(fetchAccountAction(account, [account]));
     setSessionStartTime();
     localStorage.setItem('migrated', 'true');
-    await sendMessage({
-      method: InternalMethods.ShareInMemoryKeyToBackground,
-      payload: {
-        secretKey: wallet.seedPhrase,
-      },
-    });
   };
 
   const createAccount = async () => {


### PR DESCRIPTION
# PR Type
What kind of change does this PR introduce?
- [x] Bugfix

# What is the current behavior?
When we are creating a new wallet, we don't have a wallet in the store, but the calls for Stacks and Bitcoin wallet data are firing off with an empty address and there is a constant retry in dev tools resulting in endless 404s.

# What is the new behavior?
We only make those calls if there is a bitcoin/stacks wallet address in the store.