### PR TITLE
fix: go to backup step on page refresh

### DIFF
--- a/src/app/screens/backupWalletSteps/index.tsx
+++ b/src/app/screens/backupWalletSteps/index.tsx
@@ -5,7 +5,7 @@ import useWalletReducer from '@hooks/useWalletReducer';
 import { StoreState } from '@stores/index';
 import { storeEncryptedSeedAction } from '@stores/wallet/actions/actionCreators';
 import { encryptSeedPhrase } from '@utils/encryptionUtils';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
@@ -46,6 +46,12 @@ export default function BackupWalletSteps(): JSX.Element {
   }));
   const { createWallet } = useWalletReducer();
   const { disableWalletExistsGuard } = useWalletExistsContext();
+
+  useEffect(() => {
+    if (!seedPhrase) {
+      navigate('/backup');
+    }
+  }, [seedPhrase]);
 
   const handleSeedCheckContinue = () => {
     setCurrentActiveIndex(1);

--- a/src/app/screens/createPassword/index.tsx
+++ b/src/app/screens/createPassword/index.tsx
@@ -4,7 +4,7 @@ import useWalletReducer from '@hooks/useWalletReducer';
 import { StoreState } from '@stores/index';
 import { storeEncryptedSeedAction } from '@stores/wallet/actions/actionCreators';
 import { encryptSeedPhrase } from '@utils/encryptionUtils';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
@@ -57,6 +57,12 @@ function CreatePassword(): JSX.Element {
   const { t } = useTranslation('translation', { keyPrefix: 'CREATE_PASSWORD_SCREEN' });
   const { createWallet } = useWalletReducer();
   const { disableWalletExistsGuard } = useWalletExistsContext();
+
+  useEffect(() => {
+    if (!seedPhrase) {
+      navigate('/backup');
+    }
+  }, [seedPhrase]);
 
   const handleContinuePasswordCreation = () => {
     setCurrentStepIndex(1);


### PR DESCRIPTION
# PR Type
What kind of change does this PR introduce?

- [x] Bugfix

# What is the current behavior?
During the wallet create flow, if a user refreshes the screen on the set password section, the page will reload without a seed phrase and we would continue the flow without one until the end when we try create a wallet, and the flow would fail due to invalid mnemonic.

# What is the new behavior?
If the password create step loads without a seedphrase, it will redirect back to the backup screen where a seed phrase would be generated.