### PR TITLE
fix: fix the confirm password logic

### DIFF
--- a/src/app/screens/backupWalletSteps/index.tsx
+++ b/src/app/screens/backupWalletSteps/index.tsx
@@ -72,15 +72,13 @@ export default function BackupWalletSteps(): JSX.Element {
   };
 
   const handleConfirmPasswordContinue = async () => {
-    try {
-      if (confirmPassword === password) {
-        disableWalletExistsGuard?.();
-        const encryptedSeed = await encryptSeedPhrase(seedPhrase, password);
-        dispatch(storeEncryptedSeedAction(encryptedSeed));
-        await createWallet(seedPhrase);
-        navigate('/wallet-success/create');
-      }
-    } catch (err) {
+    if (confirmPassword === password) {
+      disableWalletExistsGuard?.();
+      const encryptedSeed = await encryptSeedPhrase(seedPhrase, password);
+      dispatch(storeEncryptedSeedAction(encryptedSeed));
+      await createWallet(seedPhrase);
+      navigate('/wallet-success/create');
+    } else {
       setError(t('CONFIRM_PASSWORD_MATCH_ERROR'));
     }
   };


### PR DESCRIPTION
# PR Type
What kind of change does this PR introduce?

- [x] Bugfix


# What is the current behavior?
When creating a new wallet and you went through the "Backup Wallet" flow, if your password and confirmed password don't match, we don't display the error message as it's wrapped in a try catch instead of in the else.


# What is the new behavior?
If the passwords don't match, we show the error message