### PR TITLE
fix: remove back/forward capabilities form onboarding

### DIFF
--- a/src/app/components/checkBox/index.tsx
+++ b/src/app/components/checkBox/index.tsx
@@ -13,12 +13,13 @@ const CheckBoxWrapper = styled.div((props) => ({
   label: {
     marginLeft: props.theme.spacing(5),
   },
+  '> input, > label': {
+    cursor: 'pointer',
+  },
 }));
 
 function CheckBox(props: CheckBoxProps): JSX.Element {
-  const {
-    isChecked, checkBoxId, checkBoxLabel, onCheck,
-  } = props;
+  const { isChecked, checkBoxId, checkBoxLabel, onCheck } = props;
   return (
     <CheckBoxWrapper>
       <input id={checkBoxId} type="checkbox" checked={isChecked} onChange={onCheck} />

--- a/src/app/screens/backupWallet/index.tsx
+++ b/src/app/screens/backupWallet/index.tsx
@@ -69,11 +69,11 @@ function BackupWallet(): JSX.Element {
   }, []);
 
   const handleBackup = () => {
-    navigate('/backupWalletSteps');
+    navigate('/backupWalletSteps', { replace: true });
   };
 
   const handleSkip = () => {
-    navigate('/create-password');
+    navigate('/create-password', { replace: true });
   };
 
   return (

--- a/src/app/screens/backupWalletSteps/index.tsx
+++ b/src/app/screens/backupWalletSteps/index.tsx
@@ -78,7 +78,7 @@ export default function BackupWalletSteps(): JSX.Element {
         const encryptedSeed = await encryptSeedPhrase(seedPhrase, password);
         dispatch(storeEncryptedSeedAction(encryptedSeed));
         await createWallet(seedPhrase);
-        navigate('/wallet-success/create');
+        navigate('/wallet-success/create', { replace: true });
       }
     } catch (err) {
       setError(t('CONFIRM_PASSWORD_MATCH_ERROR'));

--- a/src/app/screens/createPassword/index.tsx
+++ b/src/app/screens/createPassword/index.tsx
@@ -70,7 +70,7 @@ function CreatePassword(): JSX.Element {
       dispatch(storeEncryptedSeedAction(encryptedSeed));
       await createWallet(seedPhrase);
 
-      navigate('/wallet-success/create');
+      navigate('/wallet-success/create', { replace: true });
     } else {
       setError(t('CONFIRM_PASSWORD_MATCH_ERROR'));
     }

--- a/src/app/screens/legalLinks/index.tsx
+++ b/src/app/screens/legalLinks/index.tsx
@@ -71,9 +71,9 @@ function LegalLinks() {
     saveIsTermsAccepted(true);
     const isRestore = !!searchParams.get('restore');
     if (isRestore) {
-      navigate('/restoreWallet');
+      navigate('/restoreWallet', { replace: true });
     } else {
-      navigate('/backup');
+      navigate('/backup', { replace: true });
     }
   };
   return (

--- a/src/app/screens/onboarding/index.tsx
+++ b/src/app/screens/onboarding/index.tsx
@@ -109,13 +109,13 @@ function Onboarding(): JSX.Element {
 
     if (isLegalAccepted) {
       if (isRestore) {
-        navigate('/restoreWallet');
+        navigate('/restoreWallet', { replace: true });
       } else {
-        navigate('/backup');
+        navigate('/backup', { replace: true });
       }
     } else {
       const params = isRestore ? '?restore=true' : '';
-      navigate(`/legal${params}`);
+      navigate(`/legal${params}`, { replace: true });
     }
   };
 

--- a/src/app/screens/restoreWallet/index.tsx
+++ b/src/app/screens/restoreWallet/index.tsx
@@ -83,7 +83,7 @@ function RestoreWallet(): JSX.Element {
       await restoreWallet(seed, password);
       setIsRestoring(false);
 
-      navigate('/wallet-success/restore');
+      navigate('/wallet-success/restore', { replace: true });
     } else {
       setIsRestoring(false);
       setError(t('CREATE_PASSWORD_SCREEN.CONFIRM_PASSWORD_MATCH_ERROR'));

--- a/src/app/screens/walletExists/index.tsx
+++ b/src/app/screens/walletExists/index.tsx
@@ -65,10 +65,6 @@ const CheckBoxContainer = styled.div((props) => ({
   userSelect: 'none',
 }));
 
-const CheckBoxWrapper = styled.div(() => ({
-  cursor: 'pointer',
-}));
-
 function WalletExists(): JSX.Element {
   const { t } = useTranslation('translation', { keyPrefix: 'WALLET_EXISTS_SCREEN' });
   const [userAccepted, setUserAccepted] = useState(false);
@@ -89,14 +85,12 @@ function WalletExists(): JSX.Element {
         <Subtitle>{t('SCREEN_SUBTITLE')}</Subtitle>
       </ContentContainer>
       <CheckBoxContainer>
-        <CheckBoxWrapper>
-          <CheckBox
-            checkBoxLabel={t('UNDERSTAND')}
-            isChecked={userAccepted}
-            checkBoxId="backup"
-            onCheck={handleToggleAccept}
-          />
-        </CheckBoxWrapper>
+        <CheckBox
+          checkBoxLabel={t('UNDERSTAND')}
+          isChecked={userAccepted}
+          checkBoxId="backup"
+          onCheck={handleToggleAccept}
+        />
       </CheckBoxContainer>
       <ContinueButton onClick={handleClose} disabled={!userAccepted}>
         {t('CLOSE_TAB')}


### PR DESCRIPTION
# PR Type
What kind of change does this PR introduce?
- [x] Enhancement

# What is the current behavior?
Navigating back during onboarding could cause potential issues, especially after a wallet has been created. Also, navigating to pages that regenerate a seed phrase could result in confusion for the user.

# What is the new behavior?
Navigation during onboarding is done with window.replace so that the users cannot navigate backward.