### PR TITLE
fix: wallet sync non-vanilla objects failure

### DIFF
--- a/src/app/stores/index.ts
+++ b/src/app/stores/index.ts
@@ -3,6 +3,7 @@ import { applyMiddleware, combineReducers, createStore } from 'redux';
 import { PersistConfig, persistReducer, persistStore } from 'redux-persist';
 import { createStateSyncMiddleware, initMessageListener } from 'redux-state-sync';
 import NftDataStateReducer from './nftData/reducer';
+import * as actions from './wallet/actions/types';
 import { WalletState } from './wallet/actions/types';
 import walletReducer from './wallet/reducer';
 
@@ -35,8 +36,12 @@ export type StoreState = ReturnType<typeof rootReducer>;
 
 const storeMiddleware = [
   createStateSyncMiddleware({
-    // We don't want to sync the redux-persist actions
-    blacklist: ['persist/PERSIST', 'persist/REHYDRATE'],
+    // We only want to sync seedphrase data for onboarding
+    whitelist: [
+      actions.StoreEncryptedSeedKey,
+      actions.SetWalletSeedPhraseKey,
+      actions.UnlockWalletKey,
+    ],
   }),
 ];
 const store = createStore(persistedReducer, applyMiddleware(...storeMiddleware));


### PR DESCRIPTION
# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


# What is the current behavior?
(Optional) Resolved: ENG-2265
If more than one chrome window is open and both windows have the XVerse popup open, then we sync the entire state between them, causing some objects to not deserialise properly. This causes issues when we try to use class obejcts that deserialised into native JS objects. This was evident in the balances shown in the home screen.

# What is the new behavior?
We only sync the required bits of the store, so we don't end up with invalid objects in our store.