### PR TITLE
feat: use ordinal thumbnails (ENG-2296)

### DIFF
--- a/src/app/screens/ordinalDetail/index.tsx
+++ b/src/app/screens/ordinalDetail/index.tsx
@@ -1,28 +1,28 @@
-import styled, { useTheme } from 'styled-components';
-import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
-import OrdinalsIcon from '@assets/img/nftDashboard/white_ordinals_icon.svg';
-import TopRow from '@components/topRow';
-import BottomTabBar from '@components/tabBar';
 import ArrowLeft from '@assets/img/dashboard/arrow_left.svg';
-import SquaresFour from '@assets/img/nftDashboard/squares_four.svg';
 import ArrowUp from '@assets/img/dashboard/arrow_up.svg';
 import ArrowUpRight from '@assets/img/dashboard/arrow_up_right.svg';
 import Globe from '@assets/img/nftDashboard/globe.svg';
-import ActionButton from '@components/button';
-import useWalletSelector from '@hooks/useWalletSelector';
-import { useEffect, useMemo, useState } from 'react';
-import { isBrcTransferValid } from '@secretkeylabs/xverse-core/api';
+import SquaresFour from '@assets/img/nftDashboard/squares_four.svg';
+import OrdinalsIcon from '@assets/img/nftDashboard/white_ordinals_icon.svg';
 import AccountHeaderComponent from '@components/accountHeader';
-import OrdinalImage from '@screens/ordinals/ordinalImage';
-import DescriptionTile from '@screens/nftDetail/descriptionTile';
-import InfoContainer from '@components/infoContainer';
-import usePendingOrdinalTxs from '@hooks/queries/usePendingOrdinalTx';
 import AlertMessage from '@components/alertMessage';
-import { getBtcTxStatusUrl } from '@utils/helper';
+import ActionButton from '@components/button';
+import InfoContainer from '@components/infoContainer';
+import BottomTabBar from '@components/tabBar';
+import TopRow from '@components/topRow';
+import usePendingOrdinalTxs from '@hooks/queries/usePendingOrdinalTx';
 import useNftDataSelector from '@hooks/stores/useNftDataSelector';
 import useOrdinalDataReducer from '@hooks/stores/useOrdinalReducer';
 import useTextOrdinalContent from '@hooks/useTextOrdinalContent';
+import useWalletSelector from '@hooks/useWalletSelector';
+import DescriptionTile from '@screens/nftDetail/descriptionTile';
+import OrdinalImage from '@screens/ordinals/ordinalImage';
+import { isBrcTransferValid } from '@secretkeylabs/xverse-core/api';
+import { getBtcTxStatusUrl } from '@utils/helper';
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import styled, { useTheme } from 'styled-components';
 import OrdinalAttributeComponent from './ordinalAttributeComponent';
 
 const Container = styled.div`
@@ -68,7 +68,7 @@ const OrdinalsContainer = styled.div((props) => ({
   maxWidth: 450,
   width: '60%',
   display: 'flex',
-  aspectRatio: 1,
+  aspectRatio: '1',
   flexDirection: 'column',
   justifyContent: 'flex-start',
   alignItems: 'flex-start',
@@ -80,7 +80,7 @@ const ExtensionOrdinalsContainer = styled.div((props) => ({
   maxHeight: 148,
   width: 148,
   display: 'flex',
-  aspectRatio: 1,
+  aspectRatio: '1',
   justifyContent: 'center',
   alignItems: 'center',
   borderRadius: 8,
@@ -289,9 +289,9 @@ function OrdinalDetailScreen() {
   useEffect(() => {
     if (selectedOrdinal) {
       if (
-        selectedOrdinal?.content_type.includes('image')
-        || selectedOrdinal?.content_type.includes('text')
-        || textContent?.includes('brc-721e')
+        selectedOrdinal?.content_type.includes('image') ||
+        selectedOrdinal?.content_type.includes('text') ||
+        textContent?.includes('brc-721e')
       ) {
         setNotSupportedOrdinal(false);
       } else setNotSupportedOrdinal(true);
@@ -339,7 +339,7 @@ function OrdinalDetailScreen() {
   };
 
   const openInOrdinalsExplorer = () => {
-    window.open(`https://www.ord.io/${selectedOrdinal?.number}`);
+    window.open(`https://ord.xverse.app/inscription/${selectedOrdinal?.id}`);
   };
 
   const ownedByView = (
@@ -400,15 +400,15 @@ function OrdinalDetailScreen() {
             <ColumnContainer>
               <OrdinalAttributeComponent title={t('AMOUNT_TO_MINT')} value={content.amt} />
               {!isGallery && (
-              <OrdinalAttributeComponent
-                title={t('OWNED_BY')}
-                value={`${ordinalsAddress.substring(0, 4)}...${ordinalsAddress.substring(
-                  ordinalsAddress.length - 4,
-                  ordinalsAddress.length,
-                )}`}
-                showOridnalTag
-                isAddress
-              />
+                <OrdinalAttributeComponent
+                  title={t('OWNED_BY')}
+                  value={`${ordinalsAddress.substring(0, 4)}...${ordinalsAddress.substring(
+                    ordinalsAddress.length - 4,
+                    ordinalsAddress.length,
+                  )}`}
+                  showOridnalTag
+                  isAddress
+                />
               )}
             </ColumnContainer>
           );
@@ -420,20 +420,24 @@ function OrdinalDetailScreen() {
                 <OrdinalAttributeComponent
                   title={t('BRC20_TRANSFER_STATUS')}
                   value={isTransferValid}
-                  valueColor={isBrcTransferValid(selectedOrdinal!) ? theme.colors.feedback.success : theme.colors.feedback.error}
+                  valueColor={
+                    isBrcTransferValid(selectedOrdinal!)
+                      ? theme.colors.feedback.success
+                      : theme.colors.feedback.error
+                  }
                   isAddress
                 />
               </DetailSection>
               {!isGallery && (
-              <OrdinalAttributeComponent
-                title={t('OWNED_BY')}
-                value={`${ordinalsAddress.substring(0, 4)}...${ordinalsAddress.substring(
-                  ordinalsAddress.length - 4,
-                  ordinalsAddress.length,
-                )}`}
-                showOridnalTag
-                isAddress
-              />
+                <OrdinalAttributeComponent
+                  title={t('OWNED_BY')}
+                  value={`${ordinalsAddress.substring(0, 4)}...${ordinalsAddress.substring(
+                    ordinalsAddress.length - 4,
+                    ordinalsAddress.length,
+                  )}`}
+                  showOridnalTag
+                  isAddress
+                />
               )}
             </ColumnContainer>
           );
@@ -447,15 +451,15 @@ function OrdinalDetailScreen() {
                 </MintLimitContainer>
               </Row>
               {!isGallery && (
-              <OrdinalAttributeComponent
-                title={t('OWNED_BY')}
-                value={`${ordinalsAddress.substring(0, 4)}...${ordinalsAddress.substring(
-                  ordinalsAddress.length - 4,
-                  ordinalsAddress.length,
-                )}`}
-                showOridnalTag
-                isAddress
-              />
+                <OrdinalAttributeComponent
+                  title={t('OWNED_BY')}
+                  value={`${ordinalsAddress.substring(0, 4)}...${ordinalsAddress.substring(
+                    ordinalsAddress.length - 4,
+                    ordinalsAddress.length,
+                  )}`}
+                  showOridnalTag
+                  isAddress
+                />
               )}
             </ColumnContainer>
           );
@@ -469,7 +473,9 @@ function OrdinalDetailScreen() {
 
   const extensionView = (
     <ExtensionContainer>
-      <CollectibleText>{isBrc20Ordinal ? t('BRC20_INSCRIPTION') : t('COLLECTIBLE')}</CollectibleText>
+      <CollectibleText>
+        {isBrc20Ordinal ? t('BRC20_INSCRIPTION') : t('COLLECTIBLE')}
+      </CollectibleText>
       <OrdinalTitleText>{`${t('INSCRIPTION')} ${selectedOrdinal?.number}`}</OrdinalTitleText>
       <WebGalleryButton onClick={openInGalleryView}>
         <>
@@ -477,16 +483,14 @@ function OrdinalDetailScreen() {
           <WebGalleryButtonText>{t('WEB_GALLERY')}</WebGalleryButtonText>
         </>
       </WebGalleryButton>
-      {selectedOrdinal?.content_type.includes('html') ? (
-        <ViewInExplorerButton>
-          <ActionButton
-            src={Globe}
-            text={t('VIEW_ON_ORD_IO')}
-            onPress={openInOrdinalsExplorer}
-            transparent
-          />
-        </ViewInExplorerButton>
-      ) : null}
+      <ViewInExplorerButton>
+        <ActionButton
+          src={Globe}
+          text={t('VIEW_IN_ORDINALS_EXPLORER')}
+          onPress={openInOrdinalsExplorer}
+          transparent
+        />
+      </ViewInExplorerButton>
       <ExtensionOrdinalsContainer>
         <OrdinalImage ordinal={selectedOrdinal!} />
       </ExtensionOrdinalsContainer>
@@ -518,18 +522,14 @@ function OrdinalDetailScreen() {
         <SendButtonContainer>
           <ActionButton src={ArrowUpRight} text={t('SEND')} onPress={handleSendOrdinal} />
         </SendButtonContainer>
-        {
-          selectedOrdinal?.content_type.includes('html') ? (
-          <SendButtonContainer>
-            <ActionButton
-              src={Globe}
-              text={t('VIEW_ON_ORD_IO')}
-              onPress={openInOrdinalsExplorer}
-              transparent
-            />
-          </SendButtonContainer>
-          ) : null
-        }
+        <SendButtonContainer>
+          <ActionButton
+            src={Globe}
+            text={t('VIEW_IN_ORDINALS_EXPLORER')}
+            onPress={openInOrdinalsExplorer}
+            transparent
+          />
+        </SendButtonContainer>
       </ButtonContainer>
       <RowContainer>
         <OrdinalsContainer>

--- a/src/app/screens/ordinals/brc20Tile.tsx
+++ b/src/app/screens/ordinals/brc20Tile.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable no-nested-ternary */
-import { NumericFormat } from 'react-number-format';
-import stc from 'string-to-color';
 import PlaceholderImage from '@assets/img/nftDashboard/nft_fallback.svg';
-import styled from 'styled-components';
 import OrdinalsIcon from '@assets/img/nftDashboard/white_ordinals_icon.svg';
 import { useTranslation } from 'react-i18next';
+import { NumericFormat } from 'react-number-format';
+import stc from 'string-to-color';
+import styled from 'styled-components';
 
 interface ContainerProps {
   isGalleryOpen: boolean;
@@ -12,46 +11,21 @@ interface ContainerProps {
   isSmallImage?: boolean;
 }
 
-const ImageContainer = styled.div<ContainerProps>(
-  ({
-    isGalleryOpen, inNftDetail, isSmallImage, theme,
-  }) => ({
-    display: 'flex',
-    justifyContent: 'center',
-    marginBottom: inNftDetail ? theme.spacing(8) : 0,
-    paddingTop: isGalleryOpen ? 100 : 30,
-    width: '100%',
-    height: isGalleryOpen ? (inNftDetail ? 540 : 300) : isSmallImage ? 50 : 150,
-    minHeight: isGalleryOpen ? 300 : isSmallImage ? 50 : 150,
-    maxHeight: isGalleryOpen ? (inNftDetail ? 450 : 300) : isSmallImage ? 50 : 150,
-    overflow: 'hidden',
-    position: 'relative',
-    fontSize: '3em',
-    wordWrap: 'break-word',
-    backgroundColor: '#1b1e2b',
-    borderRadius: 8,
-  }),
-);
+const ImageContainer = styled.div<ContainerProps>(() => ({
+  display: 'flex',
+  justifyContent: 'center',
+  width: '100%',
+  height: '100%',
+  backgroundColor: '#1b1e2b',
+  borderRadius: 8,
+  flexDirection: 'column',
+}));
 
 const BRC20Container = styled.div({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  justifyContent: 'flex-start',
 });
-
-const PlaceholderImageContainer = styled.div<ContainerProps>(({
-  isGalleryOpen, inNftDetail, isSmallImage, theme,
-}) => ({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  marginBottom: inNftDetail ? theme.spacing(8) : 0,
-  width: '100%',
-  height: isGalleryOpen ? (inNftDetail ? 540 : 300) : isSmallImage ? 50 : 150,
-  minHeight: isGalleryOpen ? 300 : isSmallImage ? 50 : 150,
-  maxHeight: isGalleryOpen ? (inNftDetail ? 450 : 300) : isSmallImage ? 50 : 150,
-}));
 
 const OrdinalContentText = styled.h1<TextProps>((props) => ({
   ...props.theme.body_medium_m,
@@ -133,9 +107,7 @@ interface Brc20TileProps {
 }
 
 export default function Brc20Tile(props: Brc20TileProps) {
-  const {
-    brcContent, isSmallImage, isNftDashboard, inNftDetail, isGalleryOpen,
-  } = props;
+  const { brcContent, isSmallImage, isNftDashboard, inNftDetail, isGalleryOpen } = props;
   const { t } = useTranslation('translation', { keyPrefix: 'NFT_DASHBOARD_SCREEN' });
   function renderFTIcon(ticker: string) {
     const background = stc(ticker);
@@ -152,80 +124,60 @@ export default function Brc20Tile(props: Brc20TileProps) {
     const validBrcContentValue = brcContent.replace(regex, '"');
     const content = JSON.parse(validBrcContentValue);
 
+    const generateOrdinalContent = (type: 'MINT' | 'TRANSFER' | 'DEPLOY') => (
+      <ImageContainer
+        isSmallImage={isSmallImage}
+        inNftDetail={inNftDetail}
+        isGalleryOpen={isGalleryOpen}
+      >
+        <BRC20Container>
+          <BRC20Text>{t(type)}</BRC20Text>
+          {renderFTIcon(content?.tick)}
+          {type !== 'DEPLOY' && (
+            <NumericFormat
+              value={content?.amt}
+              displayType="text"
+              thousandSeparator
+              renderText={(text) => <BRC20Text>{text}</BRC20Text>}
+            />
+          )}
+          {isNftDashboard && (
+            <OrdinalsTag>
+              <ButtonIcon src={OrdinalsIcon} />
+              <Text>{t('ORDINAL')}</Text>
+            </OrdinalsTag>
+          )}
+        </BRC20Container>
+      </ImageContainer>
+    );
+
     switch (content?.op) {
       case 'mint':
-        return (
-          <ImageContainer isSmallImage={isSmallImage} inNftDetail={inNftDetail} isGalleryOpen={isGalleryOpen}>
-            <BRC20Container>
-              <BRC20Text>{t('MINT')}</BRC20Text>
-              {renderFTIcon(content?.tick)}
-              <NumericFormat
-                value={content?.amt}
-                displayType="text"
-                thousandSeparator
-                renderText={(text) => <BRC20Text>{text}</BRC20Text>}
-              />
-              {isNftDashboard && (
-                <OrdinalsTag>
-                  <ButtonIcon src={OrdinalsIcon} />
-                  <Text>{t('ORDINAL')}</Text>
-                </OrdinalsTag>
-              )}
-            </BRC20Container>
-          </ImageContainer>
-        );
+        return generateOrdinalContent('MINT');
       case 'transfer':
-        return (
-          <ImageContainer isSmallImage={isSmallImage} inNftDetail={inNftDetail} isGalleryOpen={isGalleryOpen}>
-            <BRC20Container>
-              <BRC20Text>{t('TRANSFER')}</BRC20Text>
-              {renderFTIcon(content?.tick)}
-              <NumericFormat
-                value={content?.amt}
-                displayType="text"
-                thousandSeparator
-                renderText={(text) => <BRC20Text>{text}</BRC20Text>}
-              />
-              {isNftDashboard && (
-                <OrdinalsTag>
-                  <ButtonIcon src={OrdinalsIcon} />
-                  <Text>{t('ORDINAL')}</Text>
-                </OrdinalsTag>
-              )}
-            </BRC20Container>
-          </ImageContainer>
-        );
+        return generateOrdinalContent('TRANSFER');
       case 'deploy':
-        return (
-          <ImageContainer isSmallImage={isSmallImage} inNftDetail={inNftDetail} isGalleryOpen={isGalleryOpen}>
-            <BRC20Container>
-              <BRC20Text>{t('DEPLOY')}</BRC20Text>
-              {renderFTIcon(content?.tick)}
-              {isNftDashboard && (
-                <OrdinalsTag>
-                  <ButtonIcon src={OrdinalsIcon} />
-                  <Text>{t('ORDINAL')}</Text>
-                </OrdinalsTag>
-              )}
-            </BRC20Container>
-          </ImageContainer>
-        );
+        return generateOrdinalContent('DEPLOY');
       default:
         return (
-          <PlaceholderImageContainer isSmallImage={isSmallImage} isGalleryOpen={isGalleryOpen}>
+          <ImageContainer isSmallImage={isSmallImage} isGalleryOpen={isGalleryOpen}>
             <img src={PlaceholderImage} alt="ordinal" />
-          </PlaceholderImageContainer>
+          </ImageContainer>
         );
     }
   } catch (e) {
     return (
-      <ImageContainer isSmallImage={isSmallImage} inNftDetail={inNftDetail} isGalleryOpen={isGalleryOpen}>
+      <ImageContainer
+        isSmallImage={isSmallImage}
+        inNftDetail={inNftDetail}
+        isGalleryOpen={isGalleryOpen}
+      >
         <OrdinalContentText inNftSend={false}>{brcContent}</OrdinalContentText>
         {isNftDashboard && (
-        <OrdinalsTag>
-          <ButtonIcon src={OrdinalsIcon} />
-          <Text>{t('ORDINAL')}</Text>
-        </OrdinalsTag>
+          <OrdinalsTag>
+            <ButtonIcon src={OrdinalsIcon} />
+            <Text>{t('ORDINAL')}</Text>
+          </OrdinalsTag>
         )}
       </ImageContainer>
     );

--- a/src/app/screens/ordinals/index.tsx
+++ b/src/app/screens/ordinals/index.tsx
@@ -1,9 +1,8 @@
-import styled from 'styled-components';
-import { Inscription } from '@secretkeylabs/xverse-core/types/index';
-import { useNavigate } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
-import useNftDataReducer from '@hooks/stores/useNftReducer';
 import useOrdinalDataReducer from '@hooks/stores/useOrdinalReducer';
+import { Inscription } from '@secretkeylabs/xverse-core/types/index';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 import OrdinalImage from './ordinalImage';
 
 interface Props {
@@ -29,6 +28,7 @@ const NftImageContainer = styled.div({
   justifyContent: 'center',
   alignItems: 'center',
   width: '100%',
+  aspectRatio: '1',
   overflow: 'hidden',
 });
 
@@ -43,8 +43,12 @@ const GridItemContainer = styled.button<GridContainerProps>((props) => ({
   padding: props.showBorder ? props.theme.spacing(7) : 0,
   marginBottom: props.theme.spacing(16),
   borderRadius: props.theme.radius(3),
-  background: props.showBorder ? 'linear-gradient(27.88deg, #1D2032 0%, rgba(29, 32, 50, 0) 100%)' : 'transparent',
-  border: props.showBorder ? ` 1px solid ${props.theme.colors.background.elevation2}` : 'transparent',
+  background: props.showBorder
+    ? 'linear-gradient(27.88deg, #1D2032 0%, rgba(29, 32, 50, 0) 100%)'
+    : 'transparent',
+  border: props.showBorder
+    ? ` 1px solid ${props.theme.colors.background.elevation2}`
+    : 'transparent',
 }));
 
 function Ordinal({ asset, isGalleryOpen }: Props) {

--- a/src/app/screens/ordinals/ordinalImage.tsx
+++ b/src/app/screens/ordinals/ordinalImage.tsx
@@ -1,21 +1,18 @@
-import styled from 'styled-components';
-import { MoonLoader } from 'react-spinners';
-import OrdinalsIcon from '@assets/img/nftDashboard/white_ordinals_icon.svg';
-import { getFetchableUrl } from '@utils/helper';
 import PlaceholderImage from '@assets/img/nftDashboard/nft_fallback.svg';
-import PlaceholderHtml from '@assets/img/nftDashboard/code.svg';
-import { useTranslation } from 'react-i18next';
-import { Inscription, getErc721Metadata } from '@secretkeylabs/xverse-core';
+import OrdinalsIcon from '@assets/img/nftDashboard/white_ordinals_icon.svg';
 import useTextOrdinalContent from '@hooks/useTextOrdinalContent';
+import { Inscription, getErc721Metadata } from '@secretkeylabs/xverse-core';
+import { getFetchableUrl } from '@utils/helper';
 import Image from 'rc-image';
 import { useEffect, useState } from 'react';
-import ActionButton from '@components/button';
+import { useTranslation } from 'react-i18next';
+import { MoonLoader } from 'react-spinners';
+import styled from 'styled-components';
 import Brc20Tile from './brc20Tile';
 
 interface ContainerProps {
-  isGalleryOpen: boolean;
+  isGalleryOpen?: boolean;
   inNftDetail?: boolean;
-  isSmallImage?: boolean;
 }
 
 const ImageContainer = styled.div<ContainerProps>((props) => ({
@@ -24,15 +21,18 @@ const ImageContainer = styled.div<ContainerProps>((props) => ({
   marginBottom: props.inNftDetail ? props.theme.spacing(8) : 0,
   alignItems: 'center',
   width: '100%',
-  height: props.isGalleryOpen ? (props.inNftDetail ? 540 : 300) : props.isSmallImage ? 50 : 150,
-  minHeight: props.isGalleryOpen ? 300 : props.isSmallImage ? 50 : 150,
-  maxHeight: props.isGalleryOpen ? (props.inNftDetail ? 450 : 300) : props.isSmallImage ? 50 : 150,
+  aspectRatio: '1',
   overflow: 'hidden',
   position: 'relative',
   fontSize: '3em',
   wordWrap: 'break-word',
   backgroundColor: '#1b1e2b',
   borderRadius: 8,
+}));
+
+const FillImg = styled.img(() => ({
+  width: '100%',
+  height: '100%',
 }));
 
 const ButtonIcon = styled.img({
@@ -81,7 +81,7 @@ const Text = styled.h1((props) => ({
 
 interface TextProps {
   inNftSend?: boolean;
-  blur?: boolean
+  blur?: boolean;
 }
 
 const OrdinalContentText = styled.h1<TextProps>((props) => ({
@@ -91,6 +91,10 @@ const OrdinalContentText = styled.h1<TextProps>((props) => ({
   overflow: 'hidden',
   textAlign: 'center',
   filter: `blur(${props.blur ? '3px' : 0})`,
+  textOverflow: 'ellipsis',
+  display: '-webkit-box',
+  '-webkit-line-clamp': '4',
+  '-webkit-box-orient': 'vertical',
 }));
 
 const StyledImage = styled(Image)`
@@ -126,7 +130,10 @@ function OrdinalImage({
 
     try {
       const parsedContent = JSON.parse(textContent);
-      const erc721Metadata = await getErc721Metadata(parsedContent.contract, parsedContent.token_id);
+      const erc721Metadata = await getErc721Metadata(
+        parsedContent.contract,
+        parsedContent.token_id,
+      );
 
       const url = getFetchableUrl(erc721Metadata, 'ipfs');
 
@@ -146,14 +153,14 @@ function OrdinalImage({
   }, [textContent]);
 
   const renderImage = (tag: string, src?: string) => (
-    <ImageContainer isSmallImage={isSmallImage} isGalleryOpen={isGalleryOpen}>
+    <ImageContainer>
       <StyledImage
         width="100%"
-        placeholder={(
+        placeholder={
           <LoaderContainer isGalleryOpen={isGalleryOpen}>
             <MoonLoader color="white" size={20} />
           </LoaderContainer>
-          )}
+        }
         src={src}
       />
       {isNftDashboard && (
@@ -165,8 +172,12 @@ function OrdinalImage({
     </ImageContainer>
   );
 
+  if (ordinal?.content_type.includes('image/svg')) {
+    return renderImage(t('ORDINAL'), `https://ord.xverse.app/thumbnail/${ordinal.id}`);
+  }
+
   if (ordinal?.content_type.includes('image')) {
-    return renderImage(t('ORDINAL'), getFetchableUrl(`https://api.hiro.so/ordinals/v1/inscriptions/${ordinal.id}/content`, 'http'));
+    return renderImage(t('ORDINAL'), `https://ord.xverse.app/content/${ordinal.id}`);
   }
 
   if (textContent?.includes('brc-721e')) {
@@ -176,7 +187,7 @@ function OrdinalImage({
   if (ordinal?.content_type.includes('text')) {
     if (!textContent) {
       return (
-        <ImageContainer isSmallImage={isSmallImage} isGalleryOpen={isGalleryOpen}>
+        <ImageContainer>
           <MoonLoader color="white" size={30} />
         </ImageContainer>
       );
@@ -184,26 +195,21 @@ function OrdinalImage({
 
     if (textContent.includes('brc-20')) {
       return (
-        <Brc20Tile
-          brcContent={textContent}
-          isGalleryOpen={isGalleryOpen}
-          isNftDashboard={isNftDashboard}
-          inNftDetail={inNftDetail}
-          isSmallImage={isSmallImage}
-        />
+        <ImageContainer>
+          <Brc20Tile
+            brcContent={textContent}
+            isGalleryOpen={isGalleryOpen}
+            isNftDashboard={isNftDashboard}
+            inNftDetail={inNftDetail}
+            isSmallImage={isSmallImage}
+          />
+        </ImageContainer>
       );
     }
     if (ordinal?.content_type.includes('html')) {
       return (
-        <ImageContainer
-          isSmallImage={isSmallImage}
-          inNftDetail={inNftDetail}
-          isGalleryOpen={isGalleryOpen}
-        >
-          <div style={{display: 'flex', flexDirection: 'column'}}>
-            <img src={PlaceholderHtml} />
-            <OrdinalContentText>.html</OrdinalContentText>
-          </div>
+        <ImageContainer inNftDetail={inNftDetail}>
+          <FillImg src={`https://ord.xverse.app/thumbnail/${ordinal.id}`} alt="/html/" />
           {isNftDashboard && (
             <OrdinalsTag>
               <ButtonIcon src={OrdinalsIcon} />
@@ -214,20 +220,20 @@ function OrdinalImage({
       );
     }
     return (
-      <ImageContainer isSmallImage={isSmallImage} inNftDetail={inNftDetail} isGalleryOpen={isGalleryOpen}>
+      <ImageContainer inNftDetail={inNftDetail}>
         <OrdinalContentText inNftSend={inNftSend}>{textContent}</OrdinalContentText>
         {isNftDashboard && (
-        <OrdinalsTag>
-          <ButtonIcon src={OrdinalsIcon} />
-          <Text>{t('ORDINAL')}</Text>
-        </OrdinalsTag>
+          <OrdinalsTag>
+            <ButtonIcon src={OrdinalsIcon} />
+            <Text>{t('ORDINAL')}</Text>
+          </OrdinalsTag>
         )}
       </ImageContainer>
     );
   }
 
   return (
-    <ImageContainer isSmallImage={isSmallImage} isGalleryOpen={isGalleryOpen}>
+    <ImageContainer>
       <img src={PlaceholderImage} alt="ordinal" />
     </ImageContainer>
   );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -356,7 +356,7 @@
     "BRC20_TRANSFER_STATUS": "Status",
     "TOTAL_SUPPLY": "Total supply",
     "MINT_LIMIT": "Mint limit",
-    "VIEW_ON_ORD_IO": "View on Ord.io"
+    "VIEW_IN_ORDINALS_EXPLORER": "Open in Ordinal Viewer"
   },
   "RESET_WALLET_SCREEN": {
     "ENTER_PASSWORD": "Enter your password to reset your wallet",
@@ -548,7 +548,7 @@
     "BALANCE": "Balance"
   },
   "CACHE_MIGRATION_SCREEN": {
-    "TITLE":"Your wallet data store needs to be updated in order to remain secure.",
+    "TITLE": "Your wallet data store needs to be updated in order to remain secure.",
     "WARNING": "Please make sure you have your seed phrase backed up securely before moving forward.",
     "SUCCESS_TITLE": "Update Complete",
     "SKIP_BUTTON": "Do it later",


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Enhancement

# 📜 Background
Currently, we don't display HTML ordinals due to security risks, and SVG recursive ordinals don't work in the extension.

We want to display a thumbnail jpg preview of such ordinals.

Issue Link: [ENG-2296](https://linear.app/xverseapp/issue/ENG-2296/display-the-preview-of-a-recursive-ordinal)


# 🔄 Changes
- HTML and recursive SVG ordinals are displayed as a thumbnail in the form of a JPG created by the new ordinal viewer service.
- Some styling was fixed in the ordinal gallery within the popup and the gallery view, so BRC-20 token images are now centered regardless of where you are viewing them, and images scale while keeping their aspect ratio of 1:1
- Fixed styling of HTML ordinals
- Changed external ordinal view link to point to our ordinal viewer page instead of ord.io

# 🖼 Screenshot / 📹 Video
<img width="1430" alt="image" src="https://github.com/secretkeylabs/xverse-web-extension/assets/3322667/dc2caa81-c575-4ab6-a2a4-bb7f44e9954a">

A before shot for reference:
<img width="1287" alt="image" src="https://github.com/secretkeylabs/xverse-web-extension/assets/3322667/1be889f2-7517-4433-a1d8-e378514c990f">

This is the button on ordinals that takes you to the new ordinal viewer:
<img width="415" alt="image" src="https://github.com/secretkeylabs/xverse-web-extension/assets/3322667/84d14531-78b5-42e8-a6d9-c4f899318ad8">

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
