### PR TITLE
Fix minor confirmation screen ui issues

### DIFF
--- a/src/app/components/confirmBtcTransactionComponent/inputOutputComponent.tsx
+++ b/src/app/components/confirmBtcTransactionComponent/inputOutputComponent.tsx
@@ -159,7 +159,7 @@ function InputOutputComponent({
                 icon={IconBitcoin}
                 hideAddress
                 hideCopyButton={btcAddress === address[index] || ordinalsAddress === address[index]}
-                amount={satsToBtc(new BigNumber(input.value)).toString()}
+                amount={`${satsToBtc(new BigNumber(input.value)).toString()} BTC`}
                 address={input.userSigns ? address[index] : input.txid}
               >
                 {renderSubValue(input, address[index])}

--- a/src/app/screens/signatureRequest/collapsableContainer.tsx
+++ b/src/app/screens/signatureRequest/collapsableContainer.tsx
@@ -69,7 +69,7 @@ export default function CollapsableContainer(props: Props) {
 
   useEffect(() => {
     setInfoText(text);
-    if (text.length > 30) {
+    if (text.length > 32) {
       const concatenatedText = `${text.substring(0, 32)}...`;
       setInfoText(concatenatedText);
     } else {

--- a/src/app/screens/signatureRequest/collapsableContainer.tsx
+++ b/src/app/screens/signatureRequest/collapsableContainer.tsx
@@ -69,8 +69,8 @@ export default function CollapsableContainer(props: Props) {
 
   useEffect(() => {
     setInfoText(text);
-    if (text.length > 35) {
-      const concatenatedText = `${text.substring(0, 35)}...`;
+    if (text.length > 30) {
+      const concatenatedText = `${text.substring(0, 32)}...`;
       setInfoText(concatenatedText);
     } else {
       setShowArrow(false);

--- a/src/app/screens/signatureRequest/collapsableContainer.tsx
+++ b/src/app/screens/signatureRequest/collapsableContainer.tsx
@@ -55,8 +55,10 @@ const ExpandedContainer = styled(animated.div)({
 const Text = styled.p((props) => ({
   ...props.theme.body_medium_m,
   textAlign: 'left',
-  lineHeight: 1.6,
-  wordWrap: 'break-word',
+  width: 260,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
   color: props.theme.colors.white[0],
   marginBottom: props.theme.spacing(4),
 }));
@@ -65,14 +67,9 @@ export default function CollapsableContainer(props: Props) {
   const { title, children, text, initialValue } = props;
   const [isExpanded, setIsExpanded] = useState(initialValue);
   const [showArrow, setShowArrow] = useState(true);
-  const [infoText, setInfoText] = useState('');
 
   useEffect(() => {
-    setInfoText(text);
-    if (text.length > 32) {
-      const concatenatedText = `${text.substring(0, 32)}...`;
-      setInfoText(concatenatedText);
-    } else {
+    if (text.length < 32) {
       setShowArrow(false);
     }
     if (text === '') setShowArrow(true);
@@ -106,7 +103,7 @@ export default function CollapsableContainer(props: Props) {
         </Button>
         )}
       </RowContainer>
-      {!isExpanded && text !== '' && <Text>{infoText}</Text>}
+      {!isExpanded && text !== '' && <Text>{text}</Text>}
       <ExpandedContainer style={slideInStyles}>
         {children}
       </ExpandedContainer>


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background
Fixes minor UI issues in the signPsbt screen and sign message screen
In the sign message scree, if the hash is long then string is truncated properly so that the last character is not spilled into the second line.
In the signPsbt Screen BTC unit is also added for inputs now


Issue Link: [#[ENG-2242]](https://linear.app/xverseapp/issue/ENG-2242/transaction-confirmation-input-not-showing-unit-btc)
[#[ENG-2243]](https://linear.app/xverseapp/issue/ENG-2243/message-signing-ui-issue)


# 🔄 Changes
Minor change to fix ui in confirmBtcTransactionComponent and SignatureRequest screen

# 🖼 Screenshot / 📹 Video

<img width="392" alt="sign-ui" src="https://github.com/secretkeylabs/xverse-web-extension/assets/88320460/3f2970f7-c82f-44b6-b8cf-dd503924db3a">

<img width="378" alt="SIGN-psbt" src="https://github.com/secretkeylabs/xverse-web-extension/assets/88320460/0f246e42-0244-4736-8d9c-439af1152158">

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
