### PR TITLE
Tim/eng 2345 account switching mid ledger send ordinals flow

### DIFF
--- a/src/app/screens/confirmNftTransaction/index.tsx
+++ b/src/app/screens/confirmNftTransaction/index.tsx
@@ -20,6 +20,8 @@ import useWalletSelector from '@hooks/useWalletSelector';
 import useStxWalletData from '@hooks/queries/useStxWalletData';
 import { isLedgerAccount } from '@utils/helper';
 import { LedgerTransactionType } from '@screens/ledger/confirmLedgerTransaction';
+import { setShouldResetUserFlow } from '@stores/wallet/actions/actionCreators';
+import { useDispatch } from 'react-redux';
 
 const ScrollContainer = styled.div`
   display: flex;
@@ -96,9 +98,10 @@ const ReviewTransactionText = styled.h1((props) => ({
 function ConfirmNftTransaction() {
   const { t } = useTranslation('translation', { keyPrefix: 'CONFIRM_TRANSACTION' });
   const isGalleryOpen: boolean = document.documentElement.clientWidth > 360;
-  const { selectedAccount } = useWalletSelector();
+  const { selectedAccount, shouldResetUserFlow } = useWalletSelector();
   const navigate = useNavigate();
   const location = useLocation();
+  const dispatch = useDispatch();
   const { id } = useParams();
   const { nftData } = useNftDataSelector();
   const nftIdDetails = id!.split('::');
@@ -160,6 +163,13 @@ function ConfirmNftTransaction() {
 
     mutate({ signedTx: txs[0] });
   };
+
+  useEffect(() => {
+    if (shouldResetUserFlow) {
+      navigate('/nft-dashboard');
+      dispatch(setShouldResetUserFlow(false));
+    }
+  }, [shouldResetUserFlow]);
 
   const handleOnCancelClick = () => {
     navigate(-1);

--- a/src/app/screens/confirmOrdinalTransaction/index.tsx
+++ b/src/app/screens/confirmOrdinalTransaction/index.tsx
@@ -16,6 +16,8 @@ import useBtcClient from '@hooks/useBtcClient';
 import { isLedgerAccount } from '@utils/helper';
 import useWalletSelector from '@hooks/useWalletSelector';
 import { LedgerTransactionType } from '@screens/ledger/confirmLedgerTransaction';
+import { useDispatch } from 'react-redux';
+import { setShouldResetUserFlow } from '@stores/wallet/actions/actionCreators';
 
 const ScrollContainer = styled.div`
   display: flex;
@@ -89,11 +91,12 @@ const NFtContainer = styled.div((props) => ({
 function ConfirmOrdinalTransaction() {
   const { t } = useTranslation('translation', { keyPrefix: 'CONFIRM_TRANSACTION' });
   const isGalleryOpen: boolean = document.documentElement.clientWidth > 360;
-  const { selectedAccount } = useWalletSelector();
+  const { selectedAccount, shouldResetUserFlow } = useWalletSelector();
   const navigate = useNavigate();
   const btcClient = useBtcClient();
   const [recipientAddress, setRecipientAddress] = useState('');
   const location = useLocation();
+  const dispatch = useDispatch();
   const {
     fee, feePerVByte, signedTxHex, ordinalUtxo,
   } = location.state;
@@ -153,6 +156,13 @@ function ConfirmOrdinalTransaction() {
   const handleOnCancelClick = () => {
     navigate(-1);
   };
+
+  useEffect(() => {
+    if (shouldResetUserFlow) {
+      navigate('/nft-dashboard');
+      dispatch(setShouldResetUserFlow(false));
+    }
+  }, [shouldResetUserFlow]);
 
   return (
     <>

--- a/src/app/screens/sendNft/index.tsx
+++ b/src/app/screens/sendNft/index.tsx
@@ -20,6 +20,8 @@ import useNftDataSelector from '@hooks/stores/useNftDataSelector';
 import { NftData } from '@secretkeylabs/xverse-core/types/api/stacks/assets';
 import AccountHeaderComponent from '@components/accountHeader';
 import useNetworkSelector from '@hooks/useNetwork';
+import { setShouldResetUserFlow } from '@stores/wallet/actions/actionCreators';
+import { useDispatch } from 'react-redux';
 
 const ScrollContainer = styled.div`
   display: flex;
@@ -100,6 +102,7 @@ function SendNft() {
   const navigate = useNavigate();
   const { id } = useParams();
   const location = useLocation();
+  const dispatch = useDispatch();
   let address: string | undefined;
 
   if (location.state) {
@@ -123,6 +126,7 @@ function SendNft() {
     stxPublicKey,
     network,
     feeMultipliers,
+    shouldResetUserFlow,
   } = useWalletSelector();
   const [error, setError] = useState('');
   const [recipientAddress, setRecipientAddress] = useState('');
@@ -171,6 +175,13 @@ function SendNft() {
       });
     }
   }, [data]);
+
+  useEffect(() => {
+    if (shouldResetUserFlow) {
+      navigate('/nft-dashboard');
+      dispatch(setShouldResetUserFlow(false));
+    }
+  }, [shouldResetUserFlow]);
 
   const handleBackButtonClick = () => {
     navigate(-1);

--- a/src/app/screens/sendOrdinal/index.tsx
+++ b/src/app/screens/sendOrdinal/index.tsx
@@ -21,6 +21,7 @@ import useNftDataSelector from '@hooks/stores/useNftDataSelector';
 import useBtcClient from '@hooks/useBtcClient';
 import useTextOrdinalContent from '@hooks/useTextOrdinalContent';
 import { isLedgerAccount } from '@utils/helper';
+import { isOrdinalOwnedByAccount } from '@secretkeylabs/xverse-core/api';
 
 const ScrollContainer = styled.div`
   display: flex;
@@ -166,7 +167,14 @@ function SendOrdinal() {
     navigate(-1);
   };
 
+  const activeAccountOwnsOrdinal =
+    selectedOrdinal && selectedAccount && isOrdinalOwnedByAccount(selectedOrdinal, selectedAccount);
+
   function validateFields(associatedAddress: string): boolean {
+    if (!activeAccountOwnsOrdinal) {
+      setError(t('ERRORS.ORDINAL_NOT_OWNED'));
+      return false;
+    }
     if (!associatedAddress) {
       setError(t('ERRORS.ADDRESS_REQUIRED'));
       return false;

--- a/src/app/screens/sendOrdinal/index.tsx
+++ b/src/app/screens/sendOrdinal/index.tsx
@@ -21,6 +21,8 @@ import useNftDataSelector from '@hooks/stores/useNftDataSelector';
 import useBtcClient from '@hooks/useBtcClient';
 import useTextOrdinalContent from '@hooks/useTextOrdinalContent';
 import { isLedgerAccount } from '@utils/helper';
+import { setShouldResetUserFlow } from '@stores/wallet/actions/actionCreators';
+import { useDispatch } from 'react-redux';
 import { isOrdinalOwnedByAccount } from '@secretkeylabs/xverse-core/api';
 
 const ScrollContainer = styled.div`
@@ -103,8 +105,9 @@ function SendOrdinal() {
   const { selectedOrdinal } = useNftDataSelector();
   const btcClient = useBtcClient();
   const location = useLocation();
+  const dispatch = useDispatch();
   const {
-    network, ordinalsAddress, btcAddress, selectedAccount, seedPhrase, btcFiatRate,
+    network, ordinalsAddress, btcAddress, selectedAccount, seedPhrase, btcFiatRate, shouldResetUserFlow
   } = useWalletSelector();
   const [ordinalUtxo, setOrdinalUtxo] = useState<UTXO | undefined>(undefined);
   const [error, setError] = useState('');
@@ -166,6 +169,13 @@ function SendOrdinal() {
   const handleBackButtonClick = () => {
     navigate(-1);
   };
+
+  useEffect(() => {
+    if (shouldResetUserFlow) {
+      navigate('/nft-dashboard');
+      dispatch(setShouldResetUserFlow(false));
+    }
+  }, [shouldResetUserFlow]);
 
   const activeAccountOwnsOrdinal =
     selectedOrdinal && selectedAccount && isOrdinalOwnedByAccount(selectedOrdinal, selectedAccount);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -163,7 +163,8 @@
       "INSUFFICIENT_BALANCE": "Insufficient balance",
       "MEMO_LENGTH": "Memo exceeds allowed length",
       "INSUFFICIENT_BALANCE_FEES": "Insufficient balance when including transaction fees",
-      "NFT_SEND_DETAIL": "This Nft is already sent and is in pending state"
+      "NFT_SEND_DETAIL": "This Nft is already sent and is in pending state",
+      "ORDINAL_NOT_OWNED": "This ordinal is not owned by your active account"
     },
     "SEND_NFT": "Send NFT",
     "ASSOCIATED_BNS_DOMAIN": "Associated BNS Name",


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

- redirect user back to nft dashboard if account switch is performed (via popup)
- add a validation during send ordinal inscription to check ordinal is owned by active account

- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background

Issue Link: https://linear.app/xverseapp/issue/ENG-2345/account-switching-mid-ledger-send-ordinals-flow 
Context Link (if applicable): 

# 🔄 Changes
Enumerate the changes made in this pull request, detailing what has been modified, added, or removed. Include technical details and implications if necessary.

Impact:
- Explain the broader impact of these changes.
- How it improves performance, fixes bugs, adds functionality, etc.

# 🖼 Screenshot / 📹 Video

https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/2289a8e3-70b2-43ca-bda5-12ca3de7ab90



# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
