### PR TITLE
Tim/eng 2384 user cant add the ledger account if they dont close the

### DIFF
--- a/src/app/stores/index.ts
+++ b/src/app/stores/index.ts
@@ -42,6 +42,8 @@ const storeMiddleware = [
       actions.SetWalletSeedPhraseKey,
       actions.UnlockWalletKey,
       actions.SelectAccountKey,
+      actions.AddAccountKey,
+      actions.AddLedgerAccountKey,
     ],
   }),
 ];


### PR DESCRIPTION
# 🔘 PR Type
- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background
see ticket for repro steps:

Issue Link: https://linear.app/xverseapp/issue/ENG-2384/user-cant-add-the-ledger-account-if-they-dont-close-the-wallet-created
Context Link (if applicable):

# 🔄 Changes
- fix for the redux state sync across tabs/popup 
  - to do with adding new accounts or adding ledger accounts
  - when the "Wallet Restored" or "Wallet Created" tab still open
  - or when any other tab which dispatches AddAccount or AddLedgerAccount actions are open

Impact:
- any screen to do with adding accounts between tabs could be affected

# 🖼 Screenshot / 📹 Video

https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/8301b2d4-5761-441b-aff1-ca2871c8ded9


# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
