### PR TITLE
serialize stx transactions navigation params

### DIFF
--- a/src/app/screens/confirmFtTransaction/index.tsx
+++ b/src/app/screens/confirmFtTransaction/index.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { StacksTransaction } from '@secretkeylabs/xverse-core/types';
 import { broadcastSignedTransaction } from '@secretkeylabs/xverse-core/transactions';
+import { deserializeTransaction } from '@stacks/transactions';
 import BottomBar from '@components/tabBar';
 import ConfirmStxTransationComponent from '@components/confirmStxTransactionComponent';
 import TopRow from '@components/topRow';
@@ -20,8 +21,9 @@ function ConfirmFtTransaction() {
   const selectedNetwork = useNetworkSelector();
   const location = useLocation();
   const {
-    unsignedTx, amount, fungibleToken, memo, recepientAddress,
+    unsignedTx: seedHex, amount, fungibleToken, memo, recepientAddress,
   } = location.state;
+  const unsignedTx = deserializeTransaction(seedHex);
   const {
     refetch,
   } = useStxWalletData();
@@ -38,7 +40,7 @@ function ConfirmFtTransaction() {
   } = useMutation<
   string,
   Error,
-  { signedTx: StacksTransaction }>(async ({ signedTx }) => broadcastSignedTransaction(signedTx, selectedNetwork));
+  { signedTx: StacksTransaction }>({ mutationFn: async ({ signedTx }) => broadcastSignedTransaction(signedTx, selectedNetwork) });
 
   useEffect(() => {
     if (stxTxBroadcastData) {

--- a/src/app/screens/confirmNftTransaction/index.tsx
+++ b/src/app/screens/confirmNftTransaction/index.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { StacksTransaction } from '@secretkeylabs/xverse-core/types';
 import { broadcastSignedTransaction } from '@secretkeylabs/xverse-core/transactions';
+import { deserializeTransaction } from '@stacks/transactions';
 import ArrowLeft from '@assets/img/dashboard/arrow_left.svg';
 import BottomBar from '@components/tabBar';
 import AssetIcon from '@assets/img/transactions/Assets.svg';
@@ -100,7 +101,8 @@ function ConfirmNftTransaction() {
   const { nftData } = useNftDataSelector();
   const nftIdDetails = id!.split('::');
   const nft = nftData.find((nftItem) => nftItem?.asset_id === nftIdDetails[1]);
-  const { unsignedTx, recipientAddress } = location.state;
+  const { unsignedTx: unsignedTxHex, recipientAddress } = location.state;
+  const unsignedTx = deserializeTransaction(unsignedTxHex);
   const {
     network,
   } = useWalletSelector();
@@ -108,7 +110,6 @@ function ConfirmNftTransaction() {
     refetch,
   } = useStxWalletData();
   const selectedNetwork = useNetworkSelector();
-
   const {
     isLoading,
     error: txError,
@@ -117,7 +118,7 @@ function ConfirmNftTransaction() {
   } = useMutation<
   string,
   Error,
-  { signedTx: StacksTransaction }>(async ({ signedTx }) => broadcastSignedTransaction(signedTx, selectedNetwork));
+  { signedTx: StacksTransaction }>({ mutationFn: async ({ signedTx }) => broadcastSignedTransaction(signedTx, selectedNetwork) });
 
   useEffect(() => {
     if (stxTxBroadcastData) {

--- a/src/app/screens/confirmStxTransaction/index.tsx
+++ b/src/app/screens/confirmStxTransaction/index.tsx
@@ -20,6 +20,7 @@ import RecipientComponent from '@components/recipientComponent';
 import TransferMemoView from '@components/confirmStxTransactionComponent/transferMemoView';
 import useStxWalletData from '@hooks/queries/useStxWalletData';
 import useWalletSelector from '@hooks/useWalletSelector';
+import { deserializeTransaction } from '@stacks/transactions';
 import ConfirmStxTransationComponent from '../../components/confirmStxTransactionComponent';
 
 const AlertContainer = styled.div((props) => ({
@@ -41,8 +42,9 @@ function ConfirmStxTransaction() {
   const location = useLocation();
   const selectedNetwork = useNetworkSelector();
   const {
-    unsignedTx, sponsored, isBrowserTx, tabId, requestToken,
+    unsignedTx: stringHex, sponsored, isBrowserTx, tabId, requestToken,
   } = location.state;
+  const unsignedTx = deserializeTransaction(stringHex);
   useOnOriginTabClose(Number(tabId), () => {
     setHasTabClosed(true);
     window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -61,7 +63,7 @@ function ConfirmStxTransaction() {
   } = useMutation<
   string,
   Error,
-  { signedTx: StacksTransaction }>(async ({ signedTx }) => broadcastSignedTransaction(signedTx, selectedNetwork));
+  { signedTx: StacksTransaction }>({ mutationFn: async ({ signedTx }) => broadcastSignedTransaction(signedTx, selectedNetwork) });
 
   useEffect(() => {
     if (stxTxBroadcastData) {

--- a/src/app/screens/sendFt/index.tsx
+++ b/src/app/screens/sendFt/index.tsx
@@ -47,7 +47,7 @@ function SendFtScreen() {
   StacksTransaction,
   Error,
   { associatedAddress: string; amount: string; memo?: string }
-  >(async ({ associatedAddress, amount, memo }) => {
+  >({ mutationFn: async ({ associatedAddress, amount, memo }) => {
     let convertedAmount = amount;
     if (fungibleToken?.decimals) {
       convertedAmount = convertAmountToFtDecimalPlaces(amount, fungibleToken.decimals).toString();
@@ -77,13 +77,13 @@ function SendFtScreen() {
     }
 
     return unsignedTx;
-  });
+  }});
 
   useEffect(() => {
     if (data) {
       navigate('/confirm-ft-tx', {
         state: {
-          unsignedTx: data,
+          unsignedTx: data.serialize().toString('hex'),
           amount: amountToSend.toString(),
           fungibleToken,
           memo: txMemo,

--- a/src/app/screens/sendNft/index.tsx
+++ b/src/app/screens/sendNft/index.tsx
@@ -130,7 +130,7 @@ function SendNft() {
   StacksTransaction,
   Error,
   { tokenId: string; associatedAddress: string }
-  >(async ({ tokenId, associatedAddress }) => {
+  >({ mutationFn: async ({ tokenId, associatedAddress }) => {
     const principal = nft?.fully_qualified_token_id?.split('::')!;
     const name = principal[1].split(':')[0];
     const contractInfo: string[] = principal[0].split('.');
@@ -159,13 +159,13 @@ function SendNft() {
     }
     setRecipientAddress(associatedAddress);
     return unsignedTx;
-  });
+  }});
 
   useEffect(() => {
     if (data) {
       navigate(`/confirm-nft-tx/${id}`, {
         state: {
-          unsignedTx: data,
+          unsignedTx: data.serialize().toString('hex'),
           recipientAddress,
         },
       });

--- a/src/app/screens/sendStx/index.tsx
+++ b/src/app/screens/sendStx/index.tsx
@@ -45,7 +45,7 @@ function SendStxScreen() {
   StacksTransaction,
   Error,
   { associatedAddress: string; amount: string; memo?: string }
-  >(async ({ associatedAddress, amount, memo }) => {
+  >({ mutationFn: async ({ associatedAddress, amount, memo }) => {
     const unsignedSendStxTx: StacksTransaction = await generateUnsignedStxTokenTransferTransaction(
       associatedAddress,
       stxToMicrostacks(new BigNumber(amount)).toString(),
@@ -60,13 +60,13 @@ function SendStxScreen() {
       unsignedSendStxTx.setFee(fee * BigInt(feeMultipliers.stxSendTxMultiplier));
     }
     return unsignedSendStxTx;
-  });
+  }});
 
   useEffect(() => {
     if (data) {
       navigate('/confirm-stx-tx', {
         state: {
-          unsignedTx: data,
+          unsignedTx: data.serialize().toString('hex'),
         },
       });
     }

--- a/src/app/screens/transactionRequest/index.tsx
+++ b/src/app/screens/transactionRequest/index.tsx
@@ -60,7 +60,7 @@ function TransactionRequest() {
     setUnsignedTx(unsignedSendStxTx);
     navigate('/confirm-stx-tx', {
       state: {
-        unsignedTx: unsignedSendStxTx,
+        unsignedTx: unsignedSendStxTx.serialize().toString('hex'),
         sponosred: payload.sponsored,
         isBrowserTx: true,
         tabId,


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

Fix for errors thrown by parsing errors while passing transactions  between the `send-stx` screen and the `confirm-stx-tx` / `confirm-ft-tx` screens

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background
failure to navigate to the stx confirm screens without visual response on what went wrong

Issue Link: https://linear.app/xverseapp/issue/ENG-2410/cant-send-stx-and-sip-10-tokens

# 🔄 Changes
stx transactions are serialized then deserialized when being passed as navigation params

Impact:
- Explain the broader impact of these changes.
- How it improves performance, fixes bugs, adds functionality, etc.

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
