### PR TITLE
Allow send ordinal to self and display warning instead of error

### DIFF
--- a/src/app/components/sendForm/index.tsx
+++ b/src/app/components/sendForm/index.tsx
@@ -203,6 +203,8 @@ interface Props {
   recipient?: string;
   amountToSend?: string;
   stxMemo?: string;
+  onAddressInputChange?: (recipientAddress: string) => void;
+  warning?: string;
 }
 
 function SendForm({
@@ -221,6 +223,8 @@ function SendForm({
   recipient,
   amountToSend,
   stxMemo,
+  onAddressInputChange,
+  warning,
 }: Props) {
   const { t } = useTranslation('translation', { keyPrefix: 'SEND' });
   // TODO tim: use context instead of duplicated local state and parent state (as props)
@@ -377,8 +381,9 @@ function SendForm({
     </Container>
   );
 
-  const onAddressInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleAddressInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setRecipientAddress(e.target.value);
+    onAddressInputChange?.(e.target.value);
   };
 
   const getAddressInputPlaceholder = () => {
@@ -399,7 +404,7 @@ function SendForm({
           <InputField
             value={recipientAddress}
             placeholder={getAddressInputPlaceholder()}
-            onChange={onAddressInputChange}
+            onChange={handleAddressInputChange}
           />
         </InputFieldContainer>
       </AmountInputContainer>
@@ -448,6 +453,23 @@ function SendForm({
     } else if ((amount !== '' && recipientAddress !== '') || associatedAddress !== '') return true;
     return false;
   };
+
+  let displayedWarning = '';
+  if (warning) {
+    displayedWarning = warning;
+  } else {
+    switch (currencyType) {
+      case 'Ordinal':
+        displayedWarning = t('SEND_ORDINAL_WALLET_WARNING');
+        break;
+      case 'brc20-Ordinal':
+        displayedWarning = t('SEND_BRC20_ORDINAL_WALLET_WARNING');
+        break;
+      default:
+        break;
+    }
+  }
+
   return (
     <>
       <ScrollContainer>
@@ -499,14 +521,9 @@ function SendForm({
                 <InfoContainer bodyText={t('MEMO_INFO')} />
               </>
             )}
-          {currencyType === 'Ordinal' && (
+          {displayedWarning && (
             <OrdinalInfoContainer>
-              <InfoContainer bodyText={t('SEND_ORDINAL_WALLET_WARNING')} type="Warning" />
-            </OrdinalInfoContainer>
-          )}
-          {currencyType === 'brc20-Ordinal' && (
-            <OrdinalInfoContainer>
-              <InfoContainer bodyText={t('SEND_BRC20_ORDINAL_WALLET_WARNING')} />
+              <InfoContainer bodyText={displayedWarning} type="Warning" />
             </OrdinalInfoContainer>
           )}
         </OuterContainer>

--- a/src/app/screens/sendBtc/index.tsx
+++ b/src/app/screens/sendBtc/index.tsx
@@ -28,6 +28,7 @@ function SendBtcScreen() {
   const [amountError, setAmountError] = useState('');
   const [addressError, setAddressError] = useState('');
   const [recipientAddress, setRecipientAddress] = useState(enteredAddress ?? '');
+  const [warning, setWarning] = useState('');
   const [recipient, setRecipient] = useState<Recipient[]>();
   const [amount, setAmount] = useState(enteredAmountToSend ?? '');
   const { btcAddress, network, btcBalance, selectedAccount, seedPhrase, btcFiatRate } = useSelector(
@@ -111,11 +112,6 @@ function SendBtcScreen() {
       return false;
     }
 
-    if (address === btcAddress) {
-      setAddressError(t('ERRORS.SEND_TO_SELF'));
-      return false;
-    }
-
     let parsedAmount = new BigNumber(0);
 
     try {
@@ -168,6 +164,13 @@ function SendBtcScreen() {
 
   const showNavButtons = !isInOptions();
 
+  const handleInputChange = (inputAddress: string) => {
+    if (inputAddress === btcAddress) {
+      return setWarning(t('SEND_BTC_TO_SELF_WARNING'));
+    }
+    setWarning('');
+  };
+
   return (
     <>
       <TopRow title={t('SEND')} onClick={handleBackButtonClick} showBackButton={showNavButtons} />
@@ -180,6 +183,8 @@ function SendBtcScreen() {
         recipient={recipientAddress}
         amountToSend={amount}
         processing={recipientAddress !== '' && amount !== '' && isLoading}
+        onAddressInputChange={handleInputChange}
+        warning={warning}
       />
       <BottomBar tab="dashboard" />
     </>

--- a/src/app/screens/sendOrdinal/index.tsx
+++ b/src/app/screens/sendOrdinal/index.tsx
@@ -205,12 +205,18 @@ function SendOrdinal() {
     }
   };
 
+  const currencyType = textContent?.includes('brc-20') ? 'brc20-Ordinal' : 'Ordinal';
+
   const handleInputChange = (inputAddress: string) => {
     if (inputAddress === ordinalsAddress) {
-      return setWarning(t('SEND_ORDINAL_TO_SELF_WARNING'));
+      return setWarning(
+        currencyType === 'brc20-Ordinal'
+          ? t('SEND_BRC20_ORDINAL_TO_SELF_WARNING')
+          : t('SEND_ORDINAL_TO_SELF_WARNING'),
+      );
     }
     setWarning('');
-  }
+  };
 
   return (
     <>
@@ -235,7 +241,7 @@ function SendOrdinal() {
         )}
         <SendForm
           processing={isLoading}
-          currencyType={textContent?.includes('brc-20') ? 'brc20-Ordinal' : 'Ordinal'}
+          currencyType={currencyType}
           disableAmountInput
           recepientError={error}
           recipient={address}

--- a/src/app/screens/sendOrdinal/index.tsx
+++ b/src/app/screens/sendOrdinal/index.tsx
@@ -109,6 +109,8 @@ function SendOrdinal() {
   const [ordinalUtxo, setOrdinalUtxo] = useState<UTXO | undefined>(undefined);
   const [error, setError] = useState('');
   const [recipientAddress, setRecipientAddress] = useState('');
+  const [warning, setWarning] = useState('');
+
   const textContent = useTextOrdinalContent(selectedOrdinal!);
   const address: string | undefined = useMemo(
     () => (location.state ? location.state.recipientAddress : undefined),
@@ -193,11 +195,6 @@ function SendOrdinal() {
       return false;
     }
 
-    if (associatedAddress === ordinalsAddress) {
-      setError(t('ERRORS.SEND_TO_SELF'));
-      return false;
-    }
-
     return true;
   }
 
@@ -207,6 +204,13 @@ function SendOrdinal() {
       mutate(associatedAddress);
     }
   };
+
+  const handleInputChange = (inputAddress: string) => {
+    if (inputAddress === ordinalsAddress) {
+      return setWarning(t('SEND_ORDINAL_TO_SELF_WARNING'));
+    }
+    setWarning('');
+  }
 
   return (
     <>
@@ -236,6 +240,8 @@ function SendOrdinal() {
           recepientError={error}
           recipient={address}
           onPressSend={onPressNext}
+          onAddressInputChange={handleInputChange}
+          warning={warning}
         >
           <Container>
             <NftContainer>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -223,8 +223,10 @@
     "SWITCH_TO": "Switch to",
     "SEND_ORDINAL_TITLE": "Send Ordinal",
     "SEND_ORDINAL_WALLET_WARNING": "You are about to transfer an Ordinal. Make sure the recipient wallet supports Ordinals.",
+    "SEND_BRC20_ORDINAL_WALLET_WARNING": "Transferring this Ordinal inscription will initiate the transfer of your BRC-20 tokens.",
     "SEND_ORDINAL_TO_SELF_WARNING": "You are about to transfer an Ordinal to yourself",
-    "SEND_BRC20_ORDINAL_WALLET_WARNING": "Transferring this Ordinal inscription will initiate the transfer of your BRC-20 tokens."
+    "SEND_BRC20_ORDINAL_TO_SELF_WARNING": "You are about to transfer BRC-20 tokens to yourself",
+    "SEND_BTC_TO_SELF_WARNING": "You are about to transfer BTC to yourself"
   },
   "CONFIRM_TRANSACTION": {
     "SEND": "Confirm Transaction",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -223,6 +223,7 @@
     "SWITCH_TO": "Switch to",
     "SEND_ORDINAL_TITLE": "Send Ordinal",
     "SEND_ORDINAL_WALLET_WARNING": "You are about to transfer an Ordinal. Make sure the recipient wallet supports Ordinals.",
+    "SEND_ORDINAL_TO_SELF_WARNING": "You are about to transfer an Ordinal to yourself",
     "SEND_BRC20_ORDINAL_WALLET_WARNING": "Transferring this Ordinal inscription will initiate the transfer of your BRC-20 tokens."
   },
   "CONFIRM_TRANSACTION": {


### PR DESCRIPTION
# 🔘 PR Type

- [x] Enhancement

# 📜 Background
Remove the restriction on sending to your own address for Bitcoin and Ordinal/BRC-20 transfers. Show a warning that this is sending to yourself instead.

https://twitter.com/hotmonkeydeals/status/1681683889662705664?s=20

Issue Link: #[issue_number]
Context Link (if applicable):

# 🔄 Changes
- remove error validation for send ordinal or send brc-20 to self address
- add option to change warning message of SendForm component
- add onAddressInputChange hook to SendForm component
- display warning if sending ordinal to self
- display warning if sending btc to self
- display warning if sending brc-20 to self

Impact:
- changed interface of the SendForm component, which is shared across other screens, but the optional props should be backward compatible

# 🖼 Screenshot / 📹 Video

https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/dc6af4b7-c8ce-43da-9dd0-fc8b10d8a795

![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/d3bf0caf-007c-4821-acab-1d5ae5dea3d8)

![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/5b50f2f7-6295-43c2-a9fb-655f67cacb4b)

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
