### PR TITLE
fix: remove static text describing swap route

### DIFF
--- a/src/app/screens/swap/swapConfirmation/routeBlock/index.tsx
+++ b/src/app/screens/swap/swapConfirmation/routeBlock/index.tsx
@@ -10,13 +10,6 @@ import { useState } from 'react';
 import { SwapConfirmationInput } from '@screens/swap/swapConfirmation/useConfirmSwap';
 import TokenImage from '@components/tokenImage';
 
-const RouteDescription = styled.p((props) => ({
-  ...props.theme.body_m,
-  fontWeight: 400,
-  color: props.theme.colors.white[400],
-  marginTop: props.theme.spacing(8),
-}));
-
 const RouteProgress = styled.div((props) => ({
   position: 'relative',
   display: 'flex',
@@ -63,19 +56,16 @@ export default function RouteBlock({ swap }: { swap: SwapConfirmationInput }) {
         <FoldButton isFold={isFold} onSwitch={() => setIsFold((prev) => !prev)} />
       </TitleContainer>
       {isFold ? null : (
-        <>
-          <RouteProgress>
-            <DashLine />
-            {swap.routers.map(({ name, image }) => (
-              <ProgressItem key={name}>
-                {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-                <TokenImage {...image} size={24} />
-                <ProgressItemText>{name}</ProgressItemText>
-              </ProgressItem>
-            ))}
-          </RouteProgress>
-          <RouteDescription>{t('ROUTE_DESC')}</RouteDescription>
-        </>
+        <RouteProgress>
+          <DashLine />
+          {swap.routers.map(({ name, image }) => (
+            <ProgressItem key={name}>
+              {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+              <TokenImage {...image} size={24} />
+              <ProgressItemText>{name}</ProgressItemText>
+            </ProgressItem>
+          ))}
+        </RouteProgress>
       )}
     </Container>
   );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -797,7 +797,6 @@
     "COPIED": "Copied",
     "COPY_YOUR_ADDRESS": "copy your address",
     "ADVANCED_SETTING": "Advanced settings",
-    "ROUTE_DESC": "For the transaction to proceed, your BTC will be swapped for xBTC and STX. There is no additional cost for you and no STX will be added to your wallet.",
     "THIS_IS_A_SPONSORED_TRANSACTION": "This is a sponsored transaction, no transaction fees will be deducted from your account."
   }
 }


### PR DESCRIPTION
# 🔘 PR Type

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background
Remove the text: "For the transaction to proceed, your BTC …"
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/db811f1f-b131-4770-9ea9-641351663a3b)

Issue Link: #[issue_number]
Context Link (if applicable):

# 🔄 Changes
- remove static text from within the Route section on swap confirmation screen

Impact:
- just the swap confirmation screen

# 🖼 Screenshot / 📹 Video
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/6954ae91-19f0-4198-83dd-9d30ac28d20a)


# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
