### PR TITLE
feat: show inscription service fee fiat amount

### DIFF
--- a/src/app/screens/confirmInscriptionRequest/index.tsx
+++ b/src/app/screens/confirmInscriptionRequest/index.tsx
@@ -300,7 +300,6 @@ function ConfirmInscriptionRequest() {
       suffix={` ${currency}`}
     />
   );
-
   return (
     <>
       {showOrdinalsDetectedAlert && (
@@ -359,6 +358,7 @@ function ConfirmInscriptionRequest() {
         <TransactionDetailComponent
           title="Inscription Service Fee"
           value={getAmountString(satsToBtc(new BigNumber(amount)), t('BTC'))}
+          subValue={getBtcFiatEquivalent(new BigNumber(amount), btcFiatRate)}
         />
         <TransferFeeView
           feePerVByte={currentFeeRate}


### PR DESCRIPTION
# 🔘 PR Type

- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background

We show the fiat amount for all line items in the BRC-20 transfer confirmation screen but not the inscription service fee.
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/ea0c2293-db72-4345-902e-5db9f13d17b1)



Issue Link: #[issue_number]
Context Link (if applicable):

# 🔄 Changes
changes: 
- show the inscription service fee amount converted to fiat rate

Impact:
- only a UI change on confirm brc20 send screen

# 🖼 Screenshot / 📹 Video
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/4d29f7d0-2339-4b5c-a0c9-39cd003f0713)


# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
