### PR TITLE
Add localization for onboarding flow Ledger Live warning screen

### DIFF
--- a/src/app/screens/ledger/importLedgerAccount/index.tsx
+++ b/src/app/screens/ledger/importLedgerAccount/index.tsx
@@ -34,9 +34,10 @@ import ArrowLeftIconSVG from '@assets/img/ledger/arrow_left_icon.svg';
 import LedgerFailView from '@components/ledger/failLedgerView';
 import LedgerConnectionView from '../../../components/ledger/connectLedgerView';
 
-// TODO: Add link to Ledger guide
-const LINK_TO_LEDGER_ACCOUNT_ISSUE_GUIDE = 'https://support.xverse.app/hc/en-us/articles/17901278165773';
-const LINK_TO_LEDGER_PASSPHRASE_GUIDE = 'https://support.xverse.app/hc/en-us/articles/17901278165773';
+const LINK_TO_LEDGER_ACCOUNT_ISSUE_GUIDE =
+  'https://support.xverse.app/hc/en-us/articles/17901278165773';
+const LINK_TO_LEDGER_PASSPHRASE_GUIDE =
+  'https://support.xverse.app/hc/en-us/articles/17901278165773';
 
 const Container = styled.div`
   display: flex;
@@ -69,12 +70,12 @@ const ImportStartImage = styled.img((props) => ({
   marginLeft: props.theme.spacing(0),
 }));
 
-const ImportStartContainer = styled.div((props) => ({
+const ImportStartContainer = styled.div({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
   maxWidth: '328px',
-}));
+});
 
 const ImportBeforeStartContainer = styled.div((props) => ({
   display: 'flex',
@@ -249,6 +250,7 @@ const ConfirmationStepsContainer = styled.div((props) => ({
 }));
 
 const OptionsContainer = styled.div((props) => ({
+  width: '100%',
   marginTop: props.theme.spacing(16),
 }));
 
@@ -747,24 +749,26 @@ function ImportLedger(): JSX.Element {
             )}
             {currentStepIndex === 0.5 && (
               <ImportBeforeStartContainer>
-                <ImportBeforeStartTitle>Before getting started</ImportBeforeStartTitle>
+                <ImportBeforeStartTitle>
+                  {t('LEDGER_BEFORE_GETTING_STARTED.TITLE')}
+                </ImportBeforeStartTitle>
                 <ImportBeforeStartText>
-                  Do you use Ledger Live with the hardware wallet device you wish to connect?
+                  {t('LEDGER_BEFORE_GETTING_STARTED.DESCRIPTION')}
                 </ImportBeforeStartText>
                 <OptionsContainer>
                   <Option
                     onClick={() => setSelectedLedgerLiveOption('using')}
                     selected={selectedLedgerLiveOption === 'using'}
                   >
-                    <OptionIcon selected={selectedLedgerLiveOption === 'using'} />I use Ledger
-                    Live with the device.
+                    <OptionIcon selected={selectedLedgerLiveOption === 'using'} />
+                    {t('LEDGER_BEFORE_GETTING_STARTED.OPTIONS.USE_LEDGER_LIVE')}
                   </Option>
                   <Option
                     onClick={() => setSelectedLedgerLiveOption('not using')}
                     selected={selectedLedgerLiveOption === 'not using'}
                   >
-                    <OptionIcon selected={selectedLedgerLiveOption === 'not using'} />I do not use
-                    Ledger Live with the device.
+                    <OptionIcon selected={selectedLedgerLiveOption === 'not using'} />
+                    {t('LEDGER_BEFORE_GETTING_STARTED.OPTIONS.DONT_USE_LEDGER_LIVE')}
                   </Option>
                 </OptionsContainer>
               </ImportBeforeStartContainer>
@@ -772,59 +776,54 @@ function ImportLedger(): JSX.Element {
             {currentStepIndex === 0.75 && (
               <ImportBeforeStartContainer>
                 <WarningIcon src={warningIcon} alt="Warning" />
-                <ImportBeforeStartTitle>Important - Please read</ImportBeforeStartTitle>
+                <ImportBeforeStartTitle>
+                  {t('LEDGER_BEFORE_GETTING_STARTED.IMPORTANT_WARNING.TITLE')}
+                </ImportBeforeStartTitle>
                 {selectedLedgerLiveOption === 'using' ? (
                   <ImportBeforeStartText>
-                    It is not recommended to use Xverse and Ledger Live, or other Bitcoin wallets
-                    with the same hardware device as this could lead to unintentional transfers of
-                    Ordinals.{' '}
+                    {t('LEDGER_BEFORE_GETTING_STARTED.IMPORTANT_WARNING.TEXT_1')}
                     <br />
                     <CustomLink
                       href={LINK_TO_LEDGER_ACCOUNT_ISSUE_GUIDE}
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      Learn More
+                      {t('LEARN_MORE')}
                     </CustomLink>
                     <br />
                     <br />
-                    You should use a separate device for Xverse and Ordinals or set a passphrase on
-                    your Ledger to create a different set of accounts for Xverse. See {' '}
+                    {t('LEDGER_BEFORE_GETTING_STARTED.IMPORTANT_WARNING.TEXT_2')}{' '}
                     <CustomLink
                       href={LINK_TO_LEDGER_PASSPHRASE_GUIDE}
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      How To Set A Passphrase For Ordinals
+                      {t('LEDGER_BEFORE_GETTING_STARTED.IMPORTANT_WARNING.PASSPHRASE_FOR_ORDINALS')}
                     </CustomLink>
                     .
                     <br />
                     <br />
-                    {`Only continue if you're an advanced user and you know what you're doing. Do not
-                    create and use a taproot address on Ledger Live if you are using Xverse.`}
+                    {t('LEDGER_BEFORE_GETTING_STARTED.IMPORTANT_WARNING.TEXT_3')}
                   </ImportBeforeStartText>
                 ) : (
                   <ImportBeforeStartText>
-                    It is not recommended to use Xverse and Ledger Live, or other Bitcoin wallets
-                    with the same device as this could lead to unintentional transfers of Ordinals.
-                    {' '}
+                    {t('LEDGER_BEFORE_GETTING_STARTED.IMPORTANT_WARNING.TEXT_1')}{' '}
                     <CustomLink
                       href={LINK_TO_LEDGER_ACCOUNT_ISSUE_GUIDE}
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      Learn More
+                      {t('LEARN_MORE')}
                     </CustomLink>
                     <br />
                     <br />
-                    You should use a separate device for Xverse and Ordinals or set a passphrase on
-                    your Ledger to create a different set of accounts for Xverse. See{' '}
+                    {t('LEDGER_BEFORE_GETTING_STARTED.IMPORTANT_WARNING.TEXT_2')}{' '}
                     <CustomLink
                       href={LINK_TO_LEDGER_PASSPHRASE_GUIDE}
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      How To Set A Passphrase For Ordinals
+                      {t('LEDGER_BEFORE_GETTING_STARTED.IMPORTANT_WARNING.PASSPHRASE_FOR_ORDINALS')}
                     </CustomLink>
                     .
                   </ImportBeforeStartText>
@@ -839,11 +838,14 @@ function ImportLedger(): JSX.Element {
                     checkedIcon={false}
                   />
                   {selectedLedgerLiveOption === 'using' ? (
-                    <TogglerText>I understand the risks and wish to continue anyway</TogglerText>
+                    <TogglerText>
+                      {t('LEDGER_BEFORE_GETTING_STARTED.IMPORTANT_WARNING.UNDERSTAND_THE_RISKS')}
+                    </TogglerText>
                   ) : (
                     <TogglerText>
-                      I understand I should not use Ledger Live or other Bitcoin wallets with the same hardware
-                      device
+                      {t(
+                        'LEDGER_BEFORE_GETTING_STARTED.IMPORTANT_WARNING.UNDERSTAND_SHOULD_NOT_USE_LEDGER_LIVE',
+                      )}
                     </TogglerText>
                   )}
                 </TogglerContainer>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -80,7 +80,25 @@
     "LEDGER_IMPORT_CLOSE_BUTTON": "Close",
     "LEDGER_IMPORT_TRY_AGAIN_BUTTON": "Try again",
     "LEDGER_IMPORT_YES_BUTTON": "Add a new account",
-    "LEDGER_IMPORT_CANCEL_BUTTON": "Cancel"
+    "LEDGER_IMPORT_CANCEL_BUTTON": "Cancel",
+    "LEARN_MORE": "Learn More",
+    "LEDGER_BEFORE_GETTING_STARTED": {
+      "TITLE": "Before getting started",
+      "DESCRIPTION": "Do you use Ledger Live with the hardware wallet device you wish to connect?",
+      "OPTIONS": {
+        "USE_LEDGER_LIVE": "I use Ledger Live with the device.",
+        "DONT_USE_LEDGER_LIVE": "I do not use Ledger Live with the device."
+      },
+      "IMPORTANT_WARNING": {
+        "TITLE": "Important - Please read",
+        "TEXT_1": "It is not recommended to use Xverse and Ledger Live, or other Bitcoin wallets with the same hardware device as this could lead to unintentional transfers of Ordinals.",
+        "TEXT_2": "You should use a separate device for Xverse and Ordinals or set a passphrase on your Ledger to create a different set of accounts for Xverse. See",
+        "TEXT_3": "Only continue if you're an advanced user and you know what you're doing. Do not create and use a taproot address on Ledger Live if you are using Xverse.",
+        "PASSPHRASE_FOR_ORDINALS": "How To Set A Passphrase For Ordinals",
+        "UNDERSTAND_THE_RISKS": "I understand the risks and wish to continue anyway",
+        "UNDERSTAND_SHOULD_NOT_USE_LEDGER_LIVE": "I understand I should not use Ledger Live or other Bitcoin wallets with the same hardware device"
+      }
+    }
   },
   "LEDGER_VERIFY_SCREEN": {
     "TITLE_VERIFY_BTC": "Verify Bitcoin payment address",


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background
The Ledger Live warning screen added as part of this PR does not have the text added to the localization files:
https://github.com/secretkeylabs/xverse-web-extension/pull/527

Issue Link: https://linear.app/xverseapp/issue/ENG-2484/add-localization-for-onboarding-flow-ledger-live-warning-screen
Context Link (if applicable):

# 🔄 Changes
- Added text from Ledger Live warning screen to the localization files
- Changed the width of the options to "100%" to make them wider (as on the design https://www.figma.com/file/FCk8jDMsC8UEfPSWnqewLY/Xverse-%E2%80%94-Extension-V2?node-id=7068%3A173661&mode=dev)

# 🖼 Screenshot / 📹 Video
<img width="437" alt="Monosnap Xverse Wallet 2023-07-26 19-22-03" src="https://github.com/secretkeylabs/xverse-web-extension/assets/36603049/b7a8c93e-39cf-48e6-b794-348da077b03a">
<img width="434" alt="Monosnap Xverse Wallet 2023-07-26 19-22-11" src="https://github.com/secretkeylabs/xverse-web-extension/assets/36603049/1d2ef9cb-4cc0-4a57-9d20-7d69bf6f36aa">
<img width="412" alt="Monosnap Xverse Wallet 2023-07-26 19-22-22" src="https://github.com/secretkeylabs/xverse-web-extension/assets/36603049/31b594e5-400b-46a0-822f-419028f36099">

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
