### PR TITLE
Tim/eng 2504 getting badnonce and conflictingnonceinmempool errors

### DIFF
--- a/src/app/screens/home/index.tsx
+++ b/src/app/screens/home/index.tsx
@@ -365,7 +365,7 @@ function Home() {
         <RowButtonContainer>
           <SquareButton src={ArrowUpRight} text={t('SEND')} onPress={onSendModalOpen} />
           <SquareButton src={ArrowDownLeft} text={t('RECEIVE')} onPress={onReceiveModalOpen} />
-          {/* <SquareButton src={Swap} text={t('SWAP')} onPress={onSwapPressed} /> */}
+          <SquareButton src={Swap} text={t('SWAP')} onPress={onSwapPressed} />
           <SquareButton src={CreditCard} text={t('BUY')} onPress={onBuyModalOpen} />
         </RowButtonContainer>
 

--- a/src/app/screens/swap/swapConfirmation/advanceSettings/index.tsx
+++ b/src/app/screens/swap/swapConfirmation/advanceSettings/index.tsx
@@ -3,7 +3,7 @@ import { microstacksToStx, stxToMicrostacks } from '@secretkeylabs/xverse-core/c
 import TransactionSettingAlert from '@components/transactionSetting';
 import BigNumber from 'bignumber.js';
 import { setFee, setNonce } from '@secretkeylabs/xverse-core';
-import { SwapConfirmationInput } from '@screens/swap/swapConfirmation/useConfirmSwap';
+import { SwapConfirmationOutput } from '@screens/swap/swapConfirmation/useConfirmSwap';
 import styled from 'styled-components';
 import SettingIcon from '@assets/img/dashboard/faders_horizontal.svg';
 import { useTranslation } from 'react-i18next';
@@ -31,7 +31,7 @@ const ButtonImage = styled.img((props) => ({
 }));
 
 type Props = {
-  swap: SwapConfirmationInput;
+  swap: SwapConfirmationOutput;
 };
 
 export function AdvanceSettings({ swap }: Props) {

--- a/src/app/screens/swap/swapConfirmation/routeBlock/index.tsx
+++ b/src/app/screens/swap/swapConfirmation/routeBlock/index.tsx
@@ -7,7 +7,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { useState } from 'react';
-import { SwapConfirmationInput } from '@screens/swap/swapConfirmation/useConfirmSwap';
+import { SwapConfirmationOutput } from '@screens/swap/swapConfirmation/useConfirmSwap';
 import TokenImage from '@components/tokenImage';
 
 const RouteProgress = styled.div((props) => ({
@@ -46,7 +46,7 @@ const ProgressItemText = styled.p((props) => ({
   marginTop: props.theme.spacing(4),
 }));
 
-export default function RouteBlock({ swap }: { swap: SwapConfirmationInput }) {
+export default function RouteBlock({ swap }: { swap: SwapConfirmationOutput }) {
   const { t } = useTranslation('translation', { keyPrefix: 'SWAP_CONFIRM_SCREEN' });
   const [isFold, setIsFold] = useState(false);
   return (

--- a/src/app/screens/swap/swapConfirmation/stxInfoBlock/index.tsx
+++ b/src/app/screens/swap/swapConfirmation/stxInfoBlock/index.tsx
@@ -8,7 +8,7 @@ import { getTruncatedAddress } from '@utils/helper';
 import { StyledToolTip } from '@components/accountRow';
 import { useCallback, useState } from 'react';
 import { EstimateUSDText } from '@screens/swap/swapTokenBlock';
-import { SwapConfirmationInput } from '@screens/swap/swapConfirmation/useConfirmSwap';
+import { SwapConfirmationOutput } from '@screens/swap/swapConfirmation/useConfirmSwap';
 import TokenImage from '@components/tokenImage';
 
 export const Container = styled.div((props) => ({
@@ -86,13 +86,13 @@ const AddressLabelText = styled.h3((props) => ({
   marginLeft: props.theme.spacing(5),
 }));
 
-const CopyButton = styled.div((props) => ({
+const CopyButton = styled.div(() => ({
   display: 'flex',
   alignItems: 'center',
   cursor: 'pointer',
 }));
 
-const CopyImg = styled.img((props) => ({
+const CopyImg = styled.img(() => ({
   width: 20,
   height: 20,
 }));
@@ -109,7 +109,7 @@ const CurrencyText = styled.p((props) => ({
 
 interface StxInfoCardProps {
   type: 'transfer' | 'receive';
-  swap: SwapConfirmationInput;
+  swap: SwapConfirmationOutput;
 }
 
 export function FoldButton({ isFold, onSwitch }: { isFold: boolean; onSwitch: () => void }) {

--- a/src/app/screens/swap/swapConfirmation/useConfirmSwap.tsx
+++ b/src/app/screens/swap/swapConfirmation/useConfirmSwap.tsx
@@ -31,7 +31,7 @@ export type SwapConfirmationInput = {
 
 export type SwapConfirmationOutput = Omit<SwapConfirmationInput, 'unsignedTx'> & {
   onConfirm: () => Promise<void>;
-  unsignedTx: StacksTransaction; // serialized hex StacksTransaction
+  unsignedTx: StacksTransaction; // deserialized StacksTransaction
 };
 
 export function useConfirmSwap(input: SwapConfirmationInput): SwapConfirmationOutput {

--- a/src/app/screens/swap/swapConfirmation/useConfirmSwap.tsx
+++ b/src/app/screens/swap/swapConfirmation/useConfirmSwap.tsx
@@ -4,6 +4,7 @@ import useWalletSelector from '@hooks/useWalletSelector';
 import {
   broadcastSignedTransaction,
   signTransaction,
+  StacksTransaction,
 } from '@secretkeylabs/xverse-core';
 import { deserializeTransaction } from '@stacks/transactions';
 import useNetworkSelector from '@hooks/useNetwork';
@@ -28,9 +29,12 @@ export type SwapConfirmationInput = {
   functionName: string;
 };
 
-export function useConfirmSwap(
-  input: SwapConfirmationInput,
-): SwapConfirmationInput & { onConfirm: () => Promise<void> } {
+export type SwapConfirmationOutput = Omit<SwapConfirmationInput, 'unsignedTx'> & {
+  onConfirm: () => Promise<void>;
+  unsignedTx: StacksTransaction; // serialized hex StacksTransaction
+};
+
+export function useConfirmSwap(input: SwapConfirmationInput): SwapConfirmationOutput {
   const { selectedAccount, seedPhrase } = useWalletSelector();
   const selectedNetwork = useNetworkSelector();
   const { isSponsored, sponsorTransaction } = useSponsoredTransaction(XVERSE_SPONSOR_2_URL);
@@ -41,6 +45,7 @@ export function useConfirmSwap(
     ...input,
     lpFeeAmount: isSponsored ? 0 : input.lpFeeAmount,
     lpFeeFiatAmount: isSponsored ? 0 : input.lpFeeFiatAmount,
+    unsignedTx,
     onConfirm: async () => {
       const signed = await signTransaction(
         unsignedTx,

--- a/src/app/screens/swap/useSwap.tsx
+++ b/src/app/screens/swap/useSwap.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from 'react';
-import { FungibleToken, microstacksToStx } from '@secretkeylabs/xverse-core';
+import {
+  FungibleToken,
+  getNewNonce,
+  microstacksToStx,
+  setNonce,
+  getNonce,
+} from '@secretkeylabs/xverse-core';
 import { useTranslation } from 'react-i18next';
 import useWalletSelector from '@hooks/useWalletSelector';
 import { TokenImageProps } from '@components/tokenImage';
@@ -12,6 +18,7 @@ import { useNavigate } from 'react-router-dom';
 import { SwapConfirmationInput } from '@screens/swap/swapConfirmation/useConfirmSwap';
 import { AnchorMode, makeUnsignedContractCall, PostConditionMode } from '@stacks/transactions';
 import useSponsoredTransaction from '@hooks/useSponsoredTransaction';
+import useStxPendingTxData from '@hooks/queries/useStxPendingTxData';
 
 // const noop = () => null;
 const isNotNull = <T extends any>(t: T | null | undefined): t is T => t != null;
@@ -120,6 +127,7 @@ export function useSwap(): UseSwap {
     stxPublicKey,
   } = useWalletSelector();
   const { isSponsored } = useSponsoredTransaction(XVERSE_SPONSOR_2_URL);
+  const { data: stxPendingTxData } = useStxPendingTxData();
 
   const acceptableCoinList =
     coinsList?.filter((c) => alexSDK.getCurrencyFrom(c.principal) != null) ?? [];
@@ -335,6 +343,12 @@ export function useSwap(): UseSwap {
               postConditions: tx.postConditions,
               sponsored: isSponsored,
             });
+
+            // bump nonce if pendingTxs
+            setNonce(
+              unsignedTx,
+              getNewNonce(stxPendingTxData?.pendingTransactions || [], getNonce(unsignedTx)),
+            );
 
             const state: SwapConfirmationInput = {
               from: selectedCurrency.from!,


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?
- [x] Bugfix

# 📜 Background

Issue Link: https://linear.app/xverseapp/issue/ENG-2504/getting-badnonce-and-conflictingnonceinmempool-errors
Context Link (if applicable):

could modify or duplicate this function in xverse-core for an alex swap transaction:
https://github.com/secretkeylabs/xverse-core/blob/86abaff1470af5724cd91b8fb04d1546964507d3/transactions/stx.ts#L280C23-L280C50

# 🔄 Changes
- fix up serialisation/deserialisation of unsignedTx when passing to AdvancedSettings component
- use getNewNonce() with pending stx transactions to ensure nonce is incremented

Impact:
- ALEX swaps likelihood of a successful transaction broadcast

# 🖼 Screenshot / 📹 Video
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/366d4bf0-f6b4-4a07-bfa0-6ce83b77fecb)
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/c6828901-2b6c-4a6e-bd20-4e3d203ca9f4)

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
