### PR TITLE
Bump xverse-core to v1.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ledgerhq/hw-transport-webusb": "^6.27.13",
         "@react-spring/web": "^9.6.1",
-        "@secretkeylabs/xverse-core": "1.4.0",
+        "@secretkeylabs/xverse-core": "1.4.2",
         "@stacks/connect": "^6.10.2",
         "@stacks/encryption": "4.3.5",
         "@stacks/stacks-blockchain-api-types": "^6.1.1",
@@ -2139,9 +2139,9 @@
       }
     },
     "node_modules/@secretkeylabs/xverse-core": {
-      "version": "1.4.0",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.4.0/0ef344168204ad68ab66687e6ce836b504edb098",
-      "integrity": "sha512-MLypZS8nqlvfndiLOYdZWiSY8S1kdllN3EuwhEMKAW1kWFDGZNp2BZXS873ZvdSvQT+kVvYYIEo4WEwUxqXWgg==",
+      "version": "1.4.2",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.4.2/18fc0439924eca24263c3501d789ca0d468f2158",
+      "integrity": "sha512-449C1mZkDsWOElWhSKi/ipAznuTeNFga6IjYTvzH+oHJwFrg86ctdzQER+nkf60Mgu88/bRe2WrxZUITYyXPeQ==",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
@@ -2157,7 +2157,7 @@
         "@zondax/ledger-stacks": "^1.0.4",
         "axios": "0.27.2",
         "base64url": "^3.0.1",
-        "bignumber.js": "9.1.0",
+        "bignumber.js": "9.1.1",
         "bip32": "^4.0.0",
         "bip39": "3.0.3",
         "bitcoin-address-validation": "^2.2.1",
@@ -2388,14 +2388,6 @@
       "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
       "dependencies": {
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@secretkeylabs/xverse-core/node_modules/bignumber.js": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
-      "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@secretkeylabs/xverse-core/node_modules/bip32": {
@@ -19799,9 +19791,9 @@
       }
     },
     "@secretkeylabs/xverse-core": {
-      "version": "1.4.0",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.4.0/0ef344168204ad68ab66687e6ce836b504edb098",
-      "integrity": "sha512-MLypZS8nqlvfndiLOYdZWiSY8S1kdllN3EuwhEMKAW1kWFDGZNp2BZXS873ZvdSvQT+kVvYYIEo4WEwUxqXWgg==",
+      "version": "1.4.2",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.4.2/18fc0439924eca24263c3501d789ca0d468f2158",
+      "integrity": "sha512-449C1mZkDsWOElWhSKi/ipAznuTeNFga6IjYTvzH+oHJwFrg86ctdzQER+nkf60Mgu88/bRe2WrxZUITYyXPeQ==",
       "requires": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
         "@noble/secp256k1": "^1.7.1",
@@ -19816,7 +19808,7 @@
         "@zondax/ledger-stacks": "^1.0.4",
         "axios": "0.27.2",
         "base64url": "^3.0.1",
-        "bignumber.js": "9.1.0",
+        "bignumber.js": "9.1.1",
         "bip32": "^4.0.0",
         "bip39": "3.0.3",
         "bitcoin-address-validation": "^2.2.1",
@@ -20027,11 +20019,6 @@
           "requires": {
             "safe-buffer": "^5.0.1"
           }
-        },
-        "bignumber.js": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
-          "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A=="
         },
         "bip32": {
           "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@ledgerhq/hw-transport-webusb": "^6.27.13",
     "@react-spring/web": "^9.6.1",
-    "@secretkeylabs/xverse-core": "1.4.0",
+    "@secretkeylabs/xverse-core": "1.4.2",
     "@stacks/connect": "^6.10.2",
     "@stacks/encryption": "4.3.5",
     "@stacks/stacks-blockchain-api-types": "^6.1.1",


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background
Bump xverse core version to fix the following:
- Support implicitly setting tapInternalKey for psbt taproot input in https://github.com/secretkeylabs/xverse-core/pull/174
- feat: add the getSponsorInfo function to call /info endpoint in https://github.com/secretkeylabs/xverse-core/pull/173
- fix(bignumber): this will solve the type issues on extension repo in https://github.com/secretkeylabs/xverse-core/pull/109
- fix: Add the sponsored param back to stx transaction type in https://github.com/secretkeylabs/xverse-core/pull/180

# 🔄 Changes
Same as above


# 🖼 Screenshot / 📹 Video
Include screenshots or a video demonstrating the changes. This is especially helpful for UI changes.

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
