### PR TITLE
fix: only show swaps button if not on a ledger account

### DIFF
--- a/src/app/screens/home/index.tsx
+++ b/src/app/screens/home/index.tsx
@@ -363,6 +363,8 @@ function Home() {
     </VerifyOrViewContainer>
   );
 
+  const showSwaps = !isLedgerAccount(selectedAccount);
+
   return (
     <>
       <AccountHeaderComponent />
@@ -384,7 +386,7 @@ function Home() {
         <RowButtonContainer>
           <SquareButton src={ArrowUpRight} text={t('SEND')} onPress={onSendModalOpen} />
           <SquareButton src={ArrowDownLeft} text={t('RECEIVE')} onPress={onReceiveModalOpen} />
-          {/* <SquareButton src={Swap} text={t('SWAP')} onPress={onSwapPressed} /> */}
+          {showSwaps && <SquareButton src={Swap} text={t('SWAP')} onPress={onSwapPressed} />}
           <SquareButton src={CreditCard} text={t('BUY')} onPress={onBuyModalOpen} />
         </RowButtonContainer>
 


### PR DESCRIPTION
# 🔘 PR Type

- [x] Bugfix

# 📜 Background

Issue Link: https://linear.app/xverseapp/issue/ENG-2508/disable-swaps-for-ledger-accounts

# 🔄 Changes
- add logic to show/hide the Swap button depending on selected account being ledger or not

Impact:
- only on home screen, show/hide of the Swap button

# 🖼 Screenshot / 📹 Video

https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/81c0e0cb-4dd4-48dc-8b19-187a9c770ae6

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
