### PR TITLE
fix: swap confirm info should display to/from depending on the direction

### DIFF
--- a/src/app/screens/swap/swapConfirmation/stxInfoBlock/index.tsx
+++ b/src/app/screens/swap/swapConfirmation/stxInfoBlock/index.tsx
@@ -151,7 +151,7 @@ export default function StxInfoBlock({ type, swap }: StxInfoCardProps) {
             </SpaceBetweenContainer>
             <EstimateUSDText>{` ~ $${token.fiatAmount} USD`}</EstimateUSDText>
           </AmountContainer>
-          <DescriptionText>{t('TO')}</DescriptionText>
+          <DescriptionText>{type === 'transfer' ? t('FROM') : t('TO')}</DescriptionText>
           <SpaceBetweenContainer>
             <ItemsCenterContainer>
               <AddressImg src={AddressIcon} />

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -808,6 +808,7 @@
     "YOU_WILL_RECEIVE": "You will receive",
     "AMOUNT": "Amount",
     "LESS_THAN_OR_EQUAL_TO": "Less than or equal to",
+    "FROM": "From",
     "TO": "To",
     "YOUR_ADDRESS": "Your address",
     "CANCEL": "Cancel",


### PR DESCRIPTION
# 🔘 PR Type

- [x] Bugfix

# 📜 Background
see linear bot
Issue: https://linear.app/xverseapp/issue/ENG-2509/swap-confirmation-post-condition-address-tofrom-issue

# 🔄 Changes
- added a to/from logic depending on the info block

Impact:
- only on swap confirm screen UI

# 🖼 Screenshot / 📹 Video
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/4035dd8f-fd42-4a92-9319-abec683fa96a)

![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/79ab595b-c958-4891-8bfb-0a8d867f3ad7)

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
