### PR TITLE
fix: ensure we are sending the correct ordinal

### DIFF
--- a/src/app/screens/sendOrdinal/index.tsx
+++ b/src/app/screens/sendOrdinal/index.tsx
@@ -1,28 +1,28 @@
-import styled from 'styled-components';
-import { useTranslation } from 'react-i18next';
-import { useEffect, useMemo, useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { ErrorCodes, ResponseError, UTXO } from '@secretkeylabs/xverse-core/types';
-import { validateBtcAddress } from '@secretkeylabs/xverse-core/wallet';
+import ArrowLeft from '@assets/img/dashboard/arrow_left.svg';
+import AccountHeaderComponent from '@components/accountHeader';
+import SendForm from '@components/sendForm';
+import BottomBar from '@components/tabBar';
+import TopRow from '@components/topRow';
+import useNftDataSelector from '@hooks/stores/useNftDataSelector';
+import useBtcClient from '@hooks/useBtcClient';
+import { useResetUserFlow } from '@hooks/useResetUserFlow';
+import useTextOrdinalContent from '@hooks/useTextOrdinalContent';
+import useWalletSelector from '@hooks/useWalletSelector';
+import OrdinalImage from '@screens/ordinals/ordinalImage';
+import { isOrdinalOwnedByAccount } from '@secretkeylabs/xverse-core/api';
+import { getBtcFiatEquivalent } from '@secretkeylabs/xverse-core/currency';
 import {
   SignedBtcTx,
   signOrdinalSendTransaction,
 } from '@secretkeylabs/xverse-core/transactions/btc';
-import useWalletSelector from '@hooks/useWalletSelector';
-import SendForm from '@components/sendForm';
-import TopRow from '@components/topRow';
-import BottomBar from '@components/tabBar';
-import AccountHeaderComponent from '@components/accountHeader';
-import OrdinalImage from '@screens/ordinals/ordinalImage';
-import ArrowLeft from '@assets/img/dashboard/arrow_left.svg';
-import { getBtcFiatEquivalent } from '@secretkeylabs/xverse-core/currency';
-import useNftDataSelector from '@hooks/stores/useNftDataSelector';
-import useBtcClient from '@hooks/useBtcClient';
-import useTextOrdinalContent from '@hooks/useTextOrdinalContent';
+import { ErrorCodes, ResponseError, UTXO } from '@secretkeylabs/xverse-core/types';
+import { validateBtcAddress } from '@secretkeylabs/xverse-core/wallet';
+import { useMutation } from '@tanstack/react-query';
 import { isLedgerAccount } from '@utils/helper';
-import { isOrdinalOwnedByAccount } from '@secretkeylabs/xverse-core/api';
-import { useResetUserFlow } from '@hooks/useResetUserFlow';
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 
 const ScrollContainer = styled.div`
   display: flex;
@@ -124,7 +124,9 @@ function SendOrdinal() {
   } = useMutation<SignedBtcTx, ResponseError, string>({
     mutationFn: async (recipient) => {
       const addressUtxos = await btcClient.getUnspentUtxos(ordinalsAddress);
-      const ordUtxo = addressUtxos.find((utx) => utx.txid === selectedOrdinal?.tx_id);
+      const ordUtxo = addressUtxos.find(
+        (utx) => `${utx.txid}:${utx.vout}` === selectedOrdinal?.output,
+      );
       setOrdinalUtxo(ordUtxo);
       if (ordUtxo) {
         const signedTx = await signOrdinalSendTransaction(


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

- [X] Bugfix

# 📜 Background
When a user received more than 1 inscription in a txn, we sometimes send out the incorrect inscription when they try to send an inscription from that transaction.

Issue Link: #2520

# 🔄 Changes
We now match on the txn id AND vout of the inscription when picking which UTXO to send instead of just the txn ID.

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
