### PR TITLE
fix: button should always be disabled when processing

### DIFF
--- a/src/app/components/button/index.tsx
+++ b/src/app/components/button/index.tsx
@@ -100,7 +100,7 @@ function ActionButton({
 
   if (transparent) {
     return (
-      <TransparentButton onClick={handleOnPress} disabled={disabled}>
+      <TransparentButton onClick={handleOnPress} disabled={disabled || processing}>
         {processing ? (
           <MoonLoader color="white" size={10} />
         ) : (
@@ -114,7 +114,7 @@ function ActionButton({
   }
 
   return (
-    <Button onClick={handleOnPress} disabled={disabled} warning={warning}>
+    <Button onClick={handleOnPress} disabled={disabled || processing} warning={warning}>
       {processing ? (
         <MoonLoader color="#12151E" size={12} />
       ) : (

--- a/src/app/screens/swap/index.tsx
+++ b/src/app/screens/swap/index.tsx
@@ -6,7 +6,7 @@ import BottomBar from '@components/tabBar';
 import SwapTokenBlock from '@screens/swap/swapTokenBlock';
 import ArrowDown from '@assets/img/swap/arrow_swap.svg';
 import { useSwap } from '@screens/swap/useSwap';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { SwapInfoBlock } from '@screens/swap/swapInfoBlock';
 import ActionButton from '@components/button';
 import CoinSelectModal from '@screens/home/coinSelectModal';
@@ -58,6 +58,18 @@ function SwapScreen() {
   const [selecting, setSelecting] = useState<'from' | 'to'>();
   const [loading, setLoading] = useState(false);
 
+  const handleClickContinue = useCallback(async () => {
+    if (swap.submitError || !swap.onSwap) {
+      return;
+    }
+    try {
+      setLoading(true);
+      await swap.onSwap();
+    } finally {
+      setLoading(false);
+    }
+  }, [swap, setLoading]);
+
   return (
     <>
       <TopRow title={t('SWAP')} onClick={() => navigate('/')} />
@@ -103,17 +115,7 @@ function SwapScreen() {
           warning={!!swap.submitError}
           text={swap.submitError ?? t('CONTINUE')}
           processing={loading}
-          onPress={async () => {
-            if (swap.submitError) {
-              return;
-            }
-            try {
-              setLoading(true);
-              swap.onSwap?.();
-            } finally {
-              setLoading(false);
-            }
-          }}
+          onPress={handleClickContinue}
         />
       </SendButtonContainer>
       <BottomBar tab="dashboard" />

--- a/src/app/screens/swap/useSwap.tsx
+++ b/src/app/screens/swap/useSwap.tsx
@@ -46,7 +46,7 @@ export type UseSwap = {
   slippage: number;
   onSlippageChanged: (slippage: number) => void;
   minReceived?: string;
-  onSwap?: () => void;
+  onSwap?: () => Promise<void>;
 };
 
 export type SelectedCurrencyState = {


### PR DESCRIPTION
# 🔘 PR Type

- [x] Bugfix

# 📜 Background
Issue Link: https://linear.app/xverseapp/issue/ENG-2525/swap-continue-button-needs-disableprogress-indicator-when-clicked

# 🔄 Changes
- fix: button should always be disabled when processing
- fix: show processing button state in swap by using await, and fix typing

Impact:
- all standard buttons are updated to be disabled if in processing state
- swap screen after clicking continue button

# 🖼 Screenshot / 📹 Video
recording created using chrome devtools 6x CPU throttling and slow 3G network throttling
https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/e9150bc3-cd64-4965-a2c3-516d9cbe8222

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
