### PR TITLE
chore: bump xverse-core to 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ledgerhq/hw-transport-webusb": "^6.27.13",
         "@react-spring/web": "^9.6.1",
-        "@secretkeylabs/xverse-core": "1.4.2",
+        "@secretkeylabs/xverse-core": "1.5.0",
         "@stacks/connect": "^6.10.2",
         "@stacks/encryption": "4.3.5",
         "@stacks/stacks-blockchain-api-types": "^6.1.1",
@@ -2139,9 +2139,9 @@
       }
     },
     "node_modules/@secretkeylabs/xverse-core": {
-      "version": "1.4.2",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.4.2/18fc0439924eca24263c3501d789ca0d468f2158",
-      "integrity": "sha512-449C1mZkDsWOElWhSKi/ipAznuTeNFga6IjYTvzH+oHJwFrg86ctdzQER+nkf60Mgu88/bRe2WrxZUITYyXPeQ==",
+      "version": "1.5.0",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.5.0/58581099268fa16d2dae4675eb405221c36e8666",
+      "integrity": "sha512-HCKndxD3IOgx5DMIocRu1KemQ8joquLS/CM8EKEKMu/g48xrkp3s9f7P46xMSpbsf6kPwP+YFi661XZ9GMFCRg==",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
@@ -19791,9 +19791,9 @@
       }
     },
     "@secretkeylabs/xverse-core": {
-      "version": "1.4.2",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.4.2/18fc0439924eca24263c3501d789ca0d468f2158",
-      "integrity": "sha512-449C1mZkDsWOElWhSKi/ipAznuTeNFga6IjYTvzH+oHJwFrg86ctdzQER+nkf60Mgu88/bRe2WrxZUITYyXPeQ==",
+      "version": "1.5.0",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.5.0/58581099268fa16d2dae4675eb405221c36e8666",
+      "integrity": "sha512-HCKndxD3IOgx5DMIocRu1KemQ8joquLS/CM8EKEKMu/g48xrkp3s9f7P46xMSpbsf6kPwP+YFi661XZ9GMFCRg==",
       "requires": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
         "@noble/secp256k1": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@ledgerhq/hw-transport-webusb": "^6.27.13",
     "@react-spring/web": "^9.6.1",
-    "@secretkeylabs/xverse-core": "1.4.2",
+    "@secretkeylabs/xverse-core": "1.5.0",
     "@stacks/connect": "^6.10.2",
     "@stacks/encryption": "4.3.5",
     "@stacks/stacks-blockchain-api-types": "^6.1.1",


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Enhancement

# 🔄 Changes
https://github.com/secretkeylabs/xverse-core/pull/197

support outputscript https://github.com/secretkeylabs/xverse-core/pull/194
add xord and fallback to hiro when required https://github.com/secretkeylabs/xverse-core/pull/187
get Tx by tx_id https://github.com/secretkeylabs/xverse-core/pull/189
fix valid brc20 transfer logic https://github.com/secretkeylabs/xverse-core/pull/193
fix linting issue and enable ci https://github.com/secretkeylabs/xverse-core/pull/176

