### PR TITLE
Tim/eng 2510 decouple list of swap tokens

### DIFF
--- a/src/app/components/tokenTile/index.tsx
+++ b/src/app/components/tokenTile/index.tsx
@@ -93,7 +93,6 @@ const LoaderImageContainer = styled.div({
 const CoinTickerText = styled.h1((props) => ({
   ...props.theme.body_bold_m,
   color: props.theme.colors.white['0'],
-  textTransform: 'uppercase',
 }));
 
 const SubText = styled.h1((props) => ({

--- a/src/app/screens/swap/useSwap.tsx
+++ b/src/app/screens/swap/useSwap.tsx
@@ -111,7 +111,8 @@ export function useSwap(): UseSwap {
   const alexSDK = useState(() => new AlexSDK())[0];
   const { t } = useTranslation('translation', { keyPrefix: 'SWAP_SCREEN' });
   const {
-    coinsList,
+    coins: supportedCoins = [],
+    coinsList: visibleCoins = [],
     stxAvailableBalance,
     stxBtcRate,
     btcFiatRate,
@@ -121,11 +122,23 @@ export function useSwap(): UseSwap {
   } = useWalletSelector();
   const { isSponsored } = useSponsoredTransaction(XVERSE_SPONSOR_2_URL);
 
-  const acceptableCoinList = (coinsList || [])
-    .filter((c) => alexSDK.getCurrencyFrom(c.principal) != null)
+  const acceptableCoinList = supportedCoins
+    .filter((sc) => alexSDK.getCurrencyFrom(sc.contract) != null)
     // TODO tim: remove this once alexsdk fix issue here
     // https://github.com/alexgo-io/alex-sdk/issues/2
-    .filter((c) => c.assetName !== 'brc20-db20');
+    .filter((sc) => sc.contract !== 'SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.brc20-db20')
+    .map<FungibleToken>((sc) => {
+      const ft = (visibleCoins || []).find((vc) => vc.principal === sc.contract);
+      return {
+        ...ft,
+        ...sc,
+        principal: sc.contract,
+        assetName: '',
+        total_sent: ft?.total_sent ?? '0',
+        total_received: ft?.total_received ?? '0',
+        balance: ft?.balance ?? '0',
+      };
+    });
 
   const [inputAmount, setInputAmount] = useState('');
   const [slippage, setSlippage] = useState(0.04);

--- a/src/app/utils/tokens.ts
+++ b/src/app/utils/tokens.ts
@@ -3,7 +3,7 @@ import { ftDecimals, getTicker } from './helper';
 
 export function getFtTicker(ft: FungibleToken) {
   if (ft?.ticker) {
-    return ft.ticker.toUpperCase();
+    return ft.ticker;
   }
   if (ft?.name) {
     return getTicker(ft.name).toUpperCase();


### PR DESCRIPTION
# 🔘 PR Type
- [x] Bugfix

# 📜 Background
Previously the alex swap token list (from/to) was controlled by visible tokens list (set by user on home screen)

Instead want the list to match that of alex swap dapp

Issue Link: ENG-2510
Context Link (if applicable):

# 🔄 Changes
- remove token uppercase enforcement
- decouple list of allowable swap tokens from visible tokens list set by the user

Impact:
- token ticker (xBTC, BTC, ALEX, sUSDT) are no longer all uppercase

# 🖼 Screenshot / 📹 Video
swap tokens from/to list:
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/2a32177d-b2fc-4fa3-a632-143b2fbf8e89)

![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/d542d6e6-fb40-49f3-8153-1fdd39ef58d5)

home screen token list (depends on user setting of visible tokens):
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/48d9b520-5ee3-47d6-a674-b55aa3ce0e53)

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
