### PR TITLE
Fix the case when address verification screen flashes when using wrong device

### DIFF
--- a/src/app/screens/ledger/confirmLedgerTransaction/index.tsx
+++ b/src/app/screens/ledger/confirmLedgerTransaction/index.tsx
@@ -289,8 +289,10 @@ function ConfirmLedgerTransaction(): JSX.Element {
       const accountId = deviceAccounts.findIndex((account) => account.id === selectedAccount.id);
 
       if (accountId === -1) {
+        setIsConnectSuccess(false);
         setIsConnectFailed(true);
         setIsWrongDevice(true);
+        setIsButtonDisabled(false);
         return;
       }
 

--- a/src/app/screens/ledger/verifyLedgerAccountAddress/index.tsx
+++ b/src/app/screens/ledger/verifyLedgerAccountAddress/index.tsx
@@ -134,6 +134,7 @@ function VerifyLedger(): JSX.Element {
   const [isBtcAddressRejected, setIsBtcAddressRejected] = useState(false);
   const [isOrdinalsAddressRejected, setIsOrdinalsAddressRejected] = useState(false);
   const { selectedAccount } = useWalletSelector();
+  const [isWrongDevice, setIsWrongDevice] = useState(false);
   const { search } = useLocation();
   const params = new URLSearchParams(search);
   const currency = params.get('currency') ?? '';
@@ -232,7 +233,22 @@ function VerifyLedger(): JSX.Element {
       setIsBtcAddressRejected(false);
       setIsOrdinalsAddressRejected(false);
       setIsButtonDisabled(true);
+
       const masterFingerPrint = await fetchMasterPubKey();
+
+      const deviceAccounts = ledgerAccountsList.filter(
+        (account) => account.masterPubKey === masterFingerPrint,
+      );
+      const accountId = deviceAccounts.findIndex((account) => account.id === selectedAccount?.id);
+
+      if (accountId === -1) {
+        setIsConnectSuccess(false);
+        setIsConnectFailed(true);
+        setIsWrongDevice(true);
+        setIsButtonDisabled(false);
+        return;
+      }
+
       setIsConnectSuccess(true);
       await ledgerDelay(1500);
       handleClickNext();
@@ -277,7 +293,9 @@ function VerifyLedger(): JSX.Element {
                 title={t('LEDGER_CONNECT.BTC_TITLE')}
                 text={t('LEDGER_CONNECT.BTC_SUBTITLE')}
                 titleFailed={t('TITLE_FAILED')}
-                textFailed={t('BTC_SUBTITLE_FAILED')}
+                textFailed={t(
+                  isWrongDevice ? 'WRONG_DEVICE_ERROR_SUBTITLE' : 'BTC_SUBTITLE_FAILED',
+                )}
                 imageDefault={LedgerConnectBtcSVG}
                 isConnectSuccess={isConnectSuccess}
                 isConnectFailed={isConnectFailed}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -118,6 +118,7 @@
     "BTC_SUBTITLE_FAILED": "Make sure your Ledger device is connected, unlocked, authorised by your browser and the Bitcoin app is open.",
     "BTC_TITLE_VERIFIED": "Bitcoin payment address verified successfully",
     "ORDINALS_TITLE_VERIFIED": "Ordinals address verified successfully",
+    "WRONG_DEVICE_ERROR_SUBTITLE": "The public key of the connected device did not match the wallet public key. Make sure you have the correct device connected.",
     "LEDGER_CONNECT": {
       "BTC_TITLE": "Connect Your Ledger",
       "BTC_SUBTITLE": "To continue, connect your Ledger device, make sure it's unlocked, and open the Bitcoin app."


### PR DESCRIPTION
# 🔘 PR Type

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background
When you try to verify address and have the wrong device connected, the address screen flashes for a second before showing an error.

We should also display a more useful message that the device is incorrect rather than connection failed.

Issue Link: #[[ENG-2507](https://linear.app/xverseapp/issue/ENG-2507/address-verification-screen-flashes-when-using-wrong-device)]
Context Link (if applicable):

# 🔄 Changes
- Fixed the case when address verification screen flashes when using wrong device
- Added the same error regarding the wrong device usage that we have for other flows like BTC sending, etc.

Impact:
- It impacts the address verification flow for ledger accounts

# 🖼 Screenshot / 📹 Video
https://github.com/secretkeylabs/xverse-web-extension/assets/36603049/139b90c3-e2c2-4f43-a431-3bd3bf1139df

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
