### PR TITLE
Integrate with ALEX's new broadcastsponsoredtx function and healthz endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
-        "alex-sdk": "^0.1.14",
+        "alex-sdk": "^0.1.18",
         "argon2-browser": "^1.18.0",
         "axios": "^1.1.3",
         "bignumber.js": "^9.1.0",
@@ -4665,9 +4665,9 @@
       }
     },
     "node_modules/alex-sdk": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/alex-sdk/-/alex-sdk-0.1.16.tgz",
-      "integrity": "sha512-btCCv+L3fCdULhmIKabj+E6Aeusc0/3C745L8YErk+JnYZTIjh5G90ihppziJq/8e9WV4o2slutunp5SUCRbzg==",
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/alex-sdk/-/alex-sdk-0.1.18.tgz",
+      "integrity": "sha512-TEBlO9Xiw/LRBZMM98o6eUqZv6q/qlkDOHQACc0kFGCdqfspcVhE1X83vMVpZYbjKlXnko6mFW6bi+RyMx2L3g==",
       "dependencies": {
         "clarity-codegen": "^0.2.0"
       },
@@ -22454,9 +22454,9 @@
       "requires": {}
     },
     "alex-sdk": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/alex-sdk/-/alex-sdk-0.1.16.tgz",
-      "integrity": "sha512-btCCv+L3fCdULhmIKabj+E6Aeusc0/3C745L8YErk+JnYZTIjh5G90ihppziJq/8e9WV4o2slutunp5SUCRbzg==",
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/alex-sdk/-/alex-sdk-0.1.18.tgz",
+      "integrity": "sha512-TEBlO9Xiw/LRBZMM98o6eUqZv6q/qlkDOHQACc0kFGCdqfspcVhE1X83vMVpZYbjKlXnko6mFW6bi+RyMx2L3g==",
       "requires": {
         "clarity-codegen": "^0.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "alex-sdk": "^0.1.14",
+    "alex-sdk": "^0.1.18",
     "argon2-browser": "^1.18.0",
     "axios": "^1.1.3",
     "bignumber.js": "^9.1.0",

--- a/src/app/hooks/useSponsoredTransaction.ts
+++ b/src/app/hooks/useSponsoredTransaction.ts
@@ -1,24 +1,25 @@
 import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { getSponsorInfo, sponsorTransaction } from '@secretkeylabs/xverse-core/api';
+import { getSponsorInfo } from '@secretkeylabs/xverse-core/api';
 import { StacksTransaction } from '@secretkeylabs/xverse-core';
+import { AlexSDK } from 'alex-sdk';
 
-export const useSponsorInfoQuery = (sponsorUrl?: string) =>
+export const useSponsorInfoQuery = () =>
   useQuery({
     queryKey: ['sponsorInfo'],
     queryFn: async () => {
       try {
-        return await getSponsorInfo(sponsorUrl);
+        return await getSponsorInfo();
       } catch (e: any) {
         return Promise.reject(e);
       }
     },
   });
 
-export const useSponsoredTransaction = (isSponsorOptionSelected: boolean, sponsorUrl?: string) => {
+export const useSponsoredTransaction = (isSponsorOptionSelected: boolean) => {
   const [isServiceRunning, setIsServiceRunning] = useState(false);
-
-  const { error, data: isActive, isLoading } = useSponsorInfoQuery(sponsorUrl);
+  const alex = new AlexSDK();
+  const { error, data: isActive, isLoading } = useSponsorInfoQuery();
 
   useEffect(() => {
     if (!isLoading && !error) {
@@ -27,7 +28,7 @@ export const useSponsoredTransaction = (isSponsorOptionSelected: boolean, sponso
   }, [isActive, error, isLoading]);
 
   const sponsorTransactionToUrl = async (signed: StacksTransaction) =>
-    sponsorTransaction(signed, sponsorUrl);
+    alex.broadcastSponsoredTx(signed.serialize().toString('hex'));
 
   return {
     isSponsored: isServiceRunning && isSponsorOptionSelected,

--- a/src/app/hooks/useSponsoredTransaction.ts
+++ b/src/app/hooks/useSponsoredTransaction.ts
@@ -1,25 +1,24 @@
 import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { getSponsorInfo } from '@secretkeylabs/xverse-core/api';
+import { getSponsorInfo, sponsorTransaction } from '@secretkeylabs/xverse-core/api';
 import { StacksTransaction } from '@secretkeylabs/xverse-core';
-import { AlexSDK } from 'alex-sdk';
 
-export const useSponsorInfoQuery = () =>
+export const useSponsorInfoQuery = (sponsorUrl?: string) =>
   useQuery({
     queryKey: ['sponsorInfo'],
     queryFn: async () => {
       try {
-        return await getSponsorInfo();
+        return await getSponsorInfo(sponsorUrl);
       } catch (e: any) {
         return Promise.reject(e);
       }
     },
   });
 
-export const useSponsoredTransaction = (isSponsorOptionSelected: boolean) => {
+export const useSponsoredTransaction = (isSponsorOptionSelected: boolean, sponsorUrl?: string) => {
   const [isServiceRunning, setIsServiceRunning] = useState(false);
-  const alex = new AlexSDK();
-  const { error, data: isActive, isLoading } = useSponsorInfoQuery();
+
+  const { error, data: isActive, isLoading } = useSponsorInfoQuery(sponsorUrl);
 
   useEffect(() => {
     if (!isLoading && !error) {
@@ -28,7 +27,7 @@ export const useSponsoredTransaction = (isSponsorOptionSelected: boolean) => {
   }, [isActive, error, isLoading]);
 
   const sponsorTransactionToUrl = async (signed: StacksTransaction) =>
-    alex.broadcastSponsoredTx(signed.serialize().toString('hex'));
+    sponsorTransaction(signed, sponsorUrl);
 
   return {
     isSponsored: isServiceRunning && isSponsorOptionSelected,

--- a/src/app/screens/swap/error.ts
+++ b/src/app/screens/swap/error.ts
@@ -1,3 +1,0 @@
-export const swapErrorList: string[] = [
-  'Transaction fee (2605779) exceeds max sponsor fee (500000)',
-];

--- a/src/app/screens/swap/swapConfirmation/index.tsx
+++ b/src/app/screens/swap/swapConfirmation/index.tsx
@@ -12,8 +12,8 @@ import { useCallback, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useConfirmSwap } from '@screens/swap/swapConfirmation/useConfirmSwap';
 import { AdvanceSettings } from '@screens/swap/swapConfirmation/advanceSettings';
-import { useSponsoredTransaction } from '@hooks/useSponsoredTransaction';
 import SponsoredTransactionIcon from '@assets/img/transactions/CircleWavyCheck.svg';
+import { useAlexSponsoredTransaction } from '../useAlexSponsoredTransaction';
 
 const TitleText = styled.div((props) => ({
   fontSize: 21,
@@ -58,7 +58,7 @@ export default function SwapConfirmation() {
   const location = useLocation();
   const navigate = useNavigate();
   const swap = useConfirmSwap(location.state);
-  const { isSponsored } = useSponsoredTransaction(swap.isSponsorOptionSelected);
+  const { isSponsored } = useAlexSponsoredTransaction(swap.userOverrideSponsorValue);
 
   const onCancel = useCallback(() => {
     navigate('/swap');

--- a/src/app/screens/swap/swapConfirmation/useConfirmSwap.tsx
+++ b/src/app/screens/swap/swapConfirmation/useConfirmSwap.tsx
@@ -12,7 +12,6 @@ import { useNavigate } from 'react-router-dom';
 import useSponsoredTransaction from '@hooks/useSponsoredTransaction';
 import { ApiResponseError } from '@secretkeylabs/xverse-core/types';
 import { TokenImageProps } from '@components/tokenImage';
-import { XVERSE_SPONSOR_2_URL } from '@utils/constants';
 import { swapErrorList } from '../error';
 
 export type SwapConfirmationInput = {
@@ -41,7 +40,6 @@ export function useConfirmSwap(input: SwapConfirmationInput): SwapConfirmationOu
   const selectedNetwork = useNetworkSelector();
   const { isSponsored, sponsorTransaction } = useSponsoredTransaction(
     input.isSponsorOptionSelected,
-    XVERSE_SPONSOR_2_URL,
   );
   const navigate = useNavigate();
   const unsignedTx = deserializeTransaction(input.unsignedTx);

--- a/src/app/screens/swap/swapConfirmation/useConfirmSwap.tsx
+++ b/src/app/screens/swap/swapConfirmation/useConfirmSwap.tsx
@@ -12,7 +12,7 @@ import { useNavigate } from 'react-router-dom';
 import useSponsoredTransaction from '@hooks/useSponsoredTransaction';
 import { ApiResponseError } from '@secretkeylabs/xverse-core/types';
 import { TokenImageProps } from '@components/tokenImage';
-import { swapErrorList } from '../error';
+import { SponsoredTxErrorCode, SponsoredTxError } from 'alex-sdk';
 
 export type SwapConfirmationInput = {
   from: Currency;
@@ -76,7 +76,18 @@ export function useConfirmSwap(input: SwapConfirmationInput): SwapConfirmationOu
           });
         }
       } catch (e) {
-        if (e instanceof Error) {
+        if (e instanceof SponsoredTxError) {
+          navigate('/tx-status', {
+            state: {
+              txid: '',
+              currency: 'STX',
+              error: e.message,
+              sponsored: isSponsored,
+              browserTx: true,
+              isSponsorServiceError: Object.values(SponsoredTxErrorCode).includes(e.code),
+            },
+          });
+        } else if (e instanceof Error) {
           navigate('/tx-status', {
             state: {
               txid: '',
@@ -84,7 +95,6 @@ export function useConfirmSwap(input: SwapConfirmationInput): SwapConfirmationOu
               error: e instanceof ApiResponseError ? e.data.message : e.message,
               sponsored: isSponsored,
               browserTx: true,
-              isSponsorServiceError: swapErrorList.includes(e.message),
             },
           });
         }

--- a/src/app/screens/swap/swapConfirmation/useConfirmSwap.tsx
+++ b/src/app/screens/swap/swapConfirmation/useConfirmSwap.tsx
@@ -80,10 +80,12 @@ export function useConfirmSwap(input: SwapConfirmationInput): SwapConfirmationOu
             state: {
               txid: '',
               currency: 'STX',
-              error: e.message,
+              error:
+                e.code !== SponsoredTxErrorCode.unknown_error ? e.message : 'Unknown sponsor error',
               sponsored: isSponsored,
               browserTx: true,
-              isSponsorServiceError: Object.values(SponsoredTxErrorCode).includes(e.code),
+              isSponsorServiceError: true,
+              isSwapTransaction: true,
             },
           });
         } else if (e instanceof Error) {
@@ -94,6 +96,7 @@ export function useConfirmSwap(input: SwapConfirmationInput): SwapConfirmationOu
               error: e instanceof ApiResponseError ? e.data.message : e.message,
               sponsored: isSponsored,
               browserTx: true,
+              isSwapTransaction: true,
             },
           });
         }

--- a/src/app/screens/swap/swapInfoBlock/index.tsx
+++ b/src/app/screens/swap/swapInfoBlock/index.tsx
@@ -61,15 +61,21 @@ const ToggleContainer = styled.div({
   justifyContent: 'flex-end',
 });
 
+const ChevronImage = styled.img<{ rotated: boolean }>(({ rotated }) => ({
+  transform: `rotate(${rotated ? 180 : 0}deg)`,
+  transition: 'transform 0.1s ease-in-out',
+}));
+
+const SlippageImg = styled.img(() => ({
+  width: 16,
+  height: 16,
+}));
+
 export function SwapInfoBlock({ swap }: { swap: UseSwap }) {
   const [expandDetail, setExpandDetail] = useState(false);
   const { t } = useTranslation('translation', { keyPrefix: 'SWAP_SCREEN' });
   const [showSlippageModal, setShowSlippageModal] = useState(false);
   const theme = useTheme();
-
-  const toggleFunction = () => {
-    swap.setIsSponsorOptionSelected(!swap.isSponsored);
-  };
 
   return (
     <>
@@ -77,14 +83,7 @@ export function SwapInfoBlock({ swap }: { swap: UseSwap }) {
         <DT>
           <DetailButton onClick={() => setExpandDetail(!expandDetail)}>
             {t('DETAILS')}
-            <img
-              alt={t('DETAILS')}
-              src={ChevronIcon}
-              style={{
-                transform: `rotate(${expandDetail ? 180 : 0}deg)`,
-                transition: 'transform 0.1s ease-in-out',
-              }}
-            />
+            <ChevronImage alt={t('DETAILS')} src={ChevronIcon} rotated={expandDetail} />
           </DetailButton>
         </DT>
         <DD>{swap.swapInfo?.exchangeRate ?? '--'}</DD>
@@ -94,12 +93,9 @@ export function SwapInfoBlock({ swap }: { swap: UseSwap }) {
             <DD>{swap.minReceived ?? '--'}</DD>
             <DT>{t('SLIPPAGE')}</DT>
             <DD>
-              <DetailButton
-                style={{ alignItems: 'center', display: 'flex' }}
-                onClick={() => setShowSlippageModal(true)}
-              >
+              <DetailButton onClick={() => setShowSlippageModal(true)}>
                 {swap.slippage * 100}%
-                <img alt={t('SLIPPAGE')} src={SlippageEditIcon} style={{ width: 16, height: 16 }} />
+                <SlippageImg alt={t('SLIPPAGE')} src={SlippageEditIcon} />
               </DetailButton>
             </DD>
             <DT>{t('LP_FEE')}</DT>
@@ -113,7 +109,7 @@ export function SwapInfoBlock({ swap }: { swap: UseSwap }) {
                   <CustomSwitch
                     onColor={theme.colors.purple_main}
                     offColor={theme.colors.background.elevation3}
-                    onChange={toggleFunction}
+                    onChange={swap.toggleUserOverrideSponsorValue}
                     checked={swap.isSponsored}
                     uncheckedIcon={false}
                     checkedIcon={false}
@@ -143,3 +139,4 @@ export function SwapInfoBlock({ swap }: { swap: UseSwap }) {
     </>
   );
 }
+export default SwapInfoBlock;

--- a/src/app/screens/swap/useAlexSponsoredTransaction.ts
+++ b/src/app/screens/swap/useAlexSponsoredTransaction.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { StacksTransaction } from '@secretkeylabs/xverse-core';
+import { AlexSDK } from 'alex-sdk';
+
+const useAlexSponsorSwapEnabledQuery = (alexSDK: AlexSDK) =>
+  useQuery({
+    queryKey: ['alexSponsoredSwapEnabled'],
+    queryFn: alexSDK.isSponsoredSwapEnabled,
+  });
+
+export const useAlexSponsoredTransaction = (userOverrideSponsorValue: boolean) => {
+  const alexSDK = useRef(new AlexSDK()).current;
+  const [isServiceRunning, setIsServiceRunning] = useState(false);
+  const { error, data: isEnabled, isLoading } = useAlexSponsorSwapEnabledQuery(alexSDK);
+
+  useEffect(() => {
+    if (!isLoading && !error) {
+      setIsServiceRunning(!!isEnabled);
+    }
+  }, [isEnabled, error, isLoading]);
+
+  const sponsorTransaction = async (signed: StacksTransaction) =>
+    alexSDK.broadcastSponsoredTx(signed.serialize().toString('hex'));
+
+  return {
+    isSponsored: userOverrideSponsorValue && isServiceRunning,
+    isServiceRunning,
+    sponsorTransaction,
+  };
+};
+
+export default useAlexSponsoredTransaction;

--- a/src/app/screens/swap/useSwap.tsx
+++ b/src/app/screens/swap/useSwap.tsx
@@ -9,7 +9,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import useWalletSelector from '@hooks/useWalletSelector';
 import { TokenImageProps } from '@components/tokenImage';
-import { LoaderSize, XVERSE_SPONSOR_2_URL } from '@utils/constants';
+import { LoaderSize } from '@utils/constants';
 import { AlexSDK, Currency } from 'alex-sdk';
 import { ftDecimals } from '@utils/helper';
 import BigNumber from 'bignumber.js';
@@ -131,10 +131,7 @@ export function useSwap(): UseSwap {
     stxPublicKey,
   } = useWalletSelector();
   const [isSponsorOptionSelected, setIsSponsorOptionSelected] = useState(true);
-  const { isSponsored, isServiceRunning } = useSponsoredTransaction(
-    isSponsorOptionSelected,
-    XVERSE_SPONSOR_2_URL,
-  );
+  const { isSponsored, isServiceRunning } = useSponsoredTransaction(isSponsorOptionSelected);
   const { data: stxPendingTxData } = useStxPendingTxData();
 
   const acceptableCoinList = supportedCoins

--- a/src/app/screens/swap/useSwap.tsx
+++ b/src/app/screens/swap/useSwap.tsx
@@ -55,7 +55,7 @@ export type UseSwap = {
   onSwap?: () => Promise<void>;
   isSponsored: boolean;
   isServiceRunning: boolean;
-  setUserOverrideSponsorValue: (isSponsored: boolean) => void;
+  toggleUserOverrideSponsorValue: () => void;
 };
 
 export type SelectedCurrencyState = {
@@ -391,6 +391,8 @@ export function useSwap(): UseSwap {
         : undefined,
     isSponsored,
     isServiceRunning,
-    setUserOverrideSponsorValue,
+    toggleUserOverrideSponsorValue: () => {
+      setUserOverrideSponsorValue((prevValue) => !prevValue);
+    },
   };
 }

--- a/src/app/screens/swap/useSwap.tsx
+++ b/src/app/screens/swap/useSwap.tsx
@@ -17,10 +17,9 @@ import { getFiatEquivalent } from '@secretkeylabs/xverse-core/transactions';
 import { useNavigate } from 'react-router-dom';
 import { SwapConfirmationInput } from '@screens/swap/swapConfirmation/useConfirmSwap';
 import { AnchorMode, makeUnsignedContractCall, PostConditionMode } from '@stacks/transactions';
-import useSponsoredTransaction from '@hooks/useSponsoredTransaction';
 import useStxPendingTxData from '@hooks/queries/useStxPendingTxData';
+import { useAlexSponsoredTransaction } from './useAlexSponsoredTransaction';
 
-// const noop = () => null;
 const isNotNull = <T extends any>(t: T | null | undefined): t is T => t != null;
 
 export type STXOrFungibleToken = 'STX' | FungibleToken;
@@ -56,7 +55,7 @@ export type UseSwap = {
   onSwap?: () => Promise<void>;
   isSponsored: boolean;
   isServiceRunning: boolean;
-  setIsSponsorOptionSelected: (isSponsored: boolean) => void;
+  setUserOverrideSponsorValue: (isSponsored: boolean) => void;
 };
 
 export type SelectedCurrencyState = {
@@ -126,12 +125,11 @@ export function useSwap(): UseSwap {
     stxAvailableBalance,
     stxBtcRate,
     btcFiatRate,
-    // fiatCurrency,
     stxAddress,
     stxPublicKey,
   } = useWalletSelector();
-  const [isSponsorOptionSelected, setIsSponsorOptionSelected] = useState(true);
-  const { isSponsored, isServiceRunning } = useSponsoredTransaction(isSponsorOptionSelected);
+  const [userOverrideSponsorValue, setUserOverrideSponsorValue] = useState(true);
+  const { isSponsored, isServiceRunning } = useAlexSponsoredTransaction(userOverrideSponsorValue);
   const { data: stxPendingTxData } = useStxPendingTxData();
 
   const acceptableCoinList = supportedCoins
@@ -384,7 +382,7 @@ export function useSwap(): UseSwap {
               routers: info.route.map(currencyToToken).filter(isNotNull),
               unsignedTx: unsignedTx.serialize().toString('hex'),
               functionName: `${tx.contractName}\n${tx.functionName}`,
-              isSponsorOptionSelected,
+              userOverrideSponsorValue,
             };
             navigate('/swap-confirm', {
               state,
@@ -393,6 +391,6 @@ export function useSwap(): UseSwap {
         : undefined,
     isSponsored,
     isServiceRunning,
-    setIsSponsorOptionSelected,
+    setUserOverrideSponsorValue,
   };
 }

--- a/src/app/screens/transactionStatus/index.tsx
+++ b/src/app/screens/transactionStatus/index.tsx
@@ -93,6 +93,9 @@ const BodyText = styled.h1((props) => ({
   color: props.theme.colors.white['400'],
   marginTop: props.theme.spacing(8),
   textAlign: 'center',
+  overflowWrap: 'break-word',
+  wordWrap: 'break-word',
+  wordBreak: 'break-word',
   marginLeft: props.theme.spacing(5),
   marginRight: props.theme.spacing(5),
 }));

--- a/src/app/screens/transactionStatus/index.tsx
+++ b/src/app/screens/transactionStatus/index.tsx
@@ -45,7 +45,9 @@ const TransactionIDContainer = styled.div((props) => ({
 const ButtonContainer = styled.div((props) => ({
   flex: 1,
   display: 'flex',
+  flexDirection: 'column',
   alignItems: 'flex-end',
+  gap: props.theme.spacing(6),
   marginTop: props.theme.spacing(15),
   marginBottom: props.theme.spacing(32),
   marginLeft: props.theme.spacing(8),
@@ -141,6 +143,7 @@ function TransactionStatus() {
   const navigate = useNavigate();
   const location = useLocation();
   const { network } = useWalletSelector();
+  // TODO tim: refactor to use react context
   const {
     txid,
     currency,
@@ -152,6 +155,7 @@ function TransactionStatus() {
     errorTitle,
     isBrc20TokenFlow,
     isSponsorServiceError,
+    isSwapTransaction,
   } = location.state;
 
   const renderTransactionSuccessStatus = (
@@ -185,6 +189,10 @@ function TransactionStatus() {
     else if (isOrdinal) navigate(-4);
     else if (isNft) navigate(-3);
     else navigate(-3);
+  };
+
+  const handleClickTrySwapAgain = () => {
+    navigate('/swap');
   };
 
   const renderLink = (
@@ -227,9 +235,16 @@ function TransactionStatus() {
           </InfoMessageContainer>
         )}
       </OuterContainer>
-      <ButtonContainer>
-        <ActionButton text={t('CLOSE')} onPress={onCloseClick} />
-      </ButtonContainer>
+      {isSwapTransaction && isSponsorServiceError ? (
+        <ButtonContainer>
+          <ActionButton text={t('RETRY')} onPress={handleClickTrySwapAgain} />
+          <ActionButton text={t('CLOSE')} onPress={onCloseClick} transparent />
+        </ButtonContainer>
+      ) : (
+        <ButtonContainer>
+          <ActionButton text={t('CLOSE')} onPress={onCloseClick} />
+        </ButtonContainer>
+      )}
     </TxStatusContainer>
   );
 }

--- a/src/app/utils/constants.ts
+++ b/src/app/utils/constants.ts
@@ -17,7 +17,6 @@ export const BTC_TRANSACTION_STATUS_URL = 'https://mempool.space/tx/';
 export const BTC_TRANSACTION_TESTNET_STATUS_URL = 'https://mempool.space/testnet/tx/';
 export const TRANSACTION_STATUS_URL = 'https://explorer.stacks.co/txid/';
 export const XVERSE_WEB_POOL_URL = 'https://pool.xverse.app';
-export const XVERSE_SPONSOR_2_URL = 'https://stacks-transaction-sponsor-swaps.onrender.com';
 
 export const TRANSAC_URL = 'https://global.transak.com';
 export const TRANSAC_API_KEY = process.env.TRANSAC_API_KEY;


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background
Use Alex sponsor service for swap transactions 

Issue Link: #[[ENG-2548](https://linear.app/xverseapp/issue/ENG-2548/integrate-with-alexs-new-broadcastsponsoredtx-function-and-healthz)]
Context Link (if applicable):

# 🔄 Changes

- The alex-sdk function broadcastsponsoredtx is used to broadcast sponsor transaction instead of using the api endpoint  `/sponsor` from core. 
- The url to check the status for sponsoring service is updated in the core [PR](https://github.com/secretkeylabs/xverse-core/pull/202) 
- alex-sdk also provides list of known codes returned by the sponsoring service `SponsoredTxErrorCode` . The PR deletes the error.ts file and compares the error code with `SponsoredTxErrorCode` from alex-sdl inorder to show the sponsoring alert prompt in the failed transaction screen


# 🖼 Screenshot / 📹 Video


https://github.com/secretkeylabs/xverse-web-extension/assets/88320460/acd1bd80-3911-4ad6-a32e-5d9a9a2865d0



https://github.com/secretkeylabs/xverse-web-extension/assets/88320460/c3bb1f8d-b706-4c5d-b9dc-9541c73c56b5



# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
