### PR TITLE
feat: add warning texts to explain why a swap cannot be sponsored

### DIFF
--- a/src/app/screens/swap/swapConfirmation/index.tsx
+++ b/src/app/screens/swap/swapConfirmation/index.tsx
@@ -13,13 +13,14 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useConfirmSwap } from '@screens/swap/swapConfirmation/useConfirmSwap';
 import { AdvanceSettings } from '@screens/swap/swapConfirmation/advanceSettings';
 import SponsoredTransactionIcon from '@assets/img/transactions/CircleWavyCheck.svg';
-import { useAlexSponsoredTransaction } from '../useAlexSponsoredTransaction';
+import InfoContainer from '@components/infoContainer';
+import { SUPPORT_URL_TAB_TARGET, SWAP_SPONSOR_DISABLED_SUPPORT_URL } from '@utils/constants';
 
 const TitleText = styled.div((props) => ({
   fontSize: 21,
   fontWeight: 700,
   color: props.theme.colors.white['0'],
-  marginBottom: props.theme.spacing(16),
+  marginBottom: props.theme.spacing(12),
   marginTop: props.theme.spacing(12),
 }));
 
@@ -53,12 +54,15 @@ const Icon = styled.img((props) => ({
   height: 24,
 }));
 
+const StyledInfoContainer = styled.div((props) => ({
+  marginBottom: props.theme.spacing(4),
+}));
+
 export default function SwapConfirmation() {
   const { t } = useTranslation('translation', { keyPrefix: 'SWAP_CONFIRM_SCREEN' });
   const location = useLocation();
   const navigate = useNavigate();
   const swap = useConfirmSwap(location.state);
-  const { isSponsored } = useAlexSponsoredTransaction(swap.userOverrideSponsorValue);
 
   const onCancel = useCallback(() => {
     navigate('/swap');
@@ -72,11 +76,25 @@ export default function SwapConfirmation() {
     });
   }, [swap]);
 
+  const handleClickLearnMore = () => {
+    window.open(SWAP_SPONSOR_DISABLED_SUPPORT_URL, SUPPORT_URL_TAB_TARGET, 'noreferrer noopener');
+  };
+
   return (
     <>
       <AccountHeaderComponent disableMenuOption disableAccountSwitch />
       <Container>
         <TitleText>{t('TOKEN_SWAP')}</TitleText>
+        {swap.isSponsorDisabled && (
+          <StyledInfoContainer>
+            <InfoContainer
+              bodyText={t('SWAP_TRANSACTION_CANNOT_BE_SPONSORED')}
+              type="Info"
+              redirectText={t('LEARN_MORE')}
+              onClick={handleClickLearnMore}
+            />
+          </StyledInfoContainer>
+        )}
         <StxInfoBlock type="transfer" swap={swap} />
         <StxInfoBlock type="receive" swap={swap} />
         <FunctionBlock name={swap.functionName} />
@@ -86,7 +104,7 @@ export default function SwapConfirmation() {
           lpFeeFiatAmount={swap.lpFeeFiatAmount}
           currency={swap.fromToken.name}
         />
-        {isSponsored ? (
+        {swap.isSponsored ? (
           <SponsoredTransactionText>
             <Icon src={SponsoredTransactionIcon} />
             {t('THIS_IS_A_SPONSORED_TRANSACTION')}

--- a/src/app/screens/swap/swapConfirmation/useConfirmSwap.tsx
+++ b/src/app/screens/swap/swapConfirmation/useConfirmSwap.tsx
@@ -32,12 +32,14 @@ export type SwapConfirmationInput = {
 export type SwapConfirmationOutput = Omit<SwapConfirmationInput, 'unsignedTx'> & {
   onConfirm: () => Promise<void>;
   unsignedTx: StacksTransaction; // deserialized StacksTransaction
+  isSponsored: boolean;
+  isSponsorDisabled: boolean;
 };
 
 export function useConfirmSwap(input: SwapConfirmationInput): SwapConfirmationOutput {
   const { selectedAccount, seedPhrase } = useWalletSelector();
   const selectedNetwork = useNetworkSelector();
-  const { isSponsored, sponsorTransaction } = useAlexSponsoredTransaction(
+  const { isSponsored, sponsorTransaction, isSponsorDisabled } = useAlexSponsoredTransaction(
     input.userOverrideSponsorValue,
   );
   const navigate = useNavigate();
@@ -49,6 +51,8 @@ export function useConfirmSwap(input: SwapConfirmationInput): SwapConfirmationOu
     lpFeeFiatAmount: isSponsored ? 0 : input.lpFeeFiatAmount,
     unsignedTx,
     userOverrideSponsorValue: input.userOverrideSponsorValue,
+    isSponsored,
+    isSponsorDisabled,
     onConfirm: async () => {
       const signed = await signTransaction(
         unsignedTx,

--- a/src/app/screens/swap/swapInfoBlock/index.tsx
+++ b/src/app/screens/swap/swapInfoBlock/index.tsx
@@ -7,6 +7,7 @@ import ChevronIcon from '@assets/img/swap/chevron.svg';
 import BottomModal from '@components/bottomModal';
 import { SlippageModalContent } from '@screens/swap/slippageModal';
 import Switch from 'react-switch';
+import { SUPPORT_URL_TAB_TARGET, SWAP_SPONSOR_DISABLED_SUPPORT_URL } from '@utils/constants';
 
 const CustomSwitch = styled(Switch)`
   .react-switch-handle {
@@ -55,12 +56,6 @@ const DD = styled.dd((props) => ({
   textAlign: 'right',
 }));
 
-const ToggleContainer = styled.div({
-  flex: '30%',
-  display: 'flex',
-  justifyContent: 'flex-end',
-});
-
 const ChevronImage = styled.img<{ rotated: boolean }>(({ rotated }) => ({
   transform: `rotate(${rotated ? 180 : 0}deg)`,
   transition: 'transform 0.1s ease-in-out',
@@ -69,6 +64,26 @@ const ChevronImage = styled.img<{ rotated: boolean }>(({ rotated }) => ({
 const SlippageImg = styled.img(() => ({
   width: 16,
   height: 16,
+}));
+
+const CannotBeSponsored = styled.p((props) => ({
+  ...props.theme.body_medium_m,
+  color: props.theme.colors.white['200'],
+}));
+
+const SponsorTransactionSwitchLabel = styled(DT)<{ disabled: boolean }>((props) => ({
+  color: props.disabled ? props.theme.colors.white['400'] : props.theme.colors.white['200'],
+}));
+
+const ToggleContainer = styled(DD)({
+  flex: 0,
+});
+
+const LearnMoreAnchor = styled.a((props) => ({
+  ...props.theme.body_bold_m,
+  color: props.theme.colors.white['0'],
+  marginTop: props.theme.spacing(2),
+  display: 'block',
 }));
 
 export function SwapInfoBlock({ swap }: { swap: UseSwap }) {
@@ -104,19 +119,39 @@ export function SwapInfoBlock({ swap }: { swap: UseSwap }) {
             <DD>{swap.swapInfo?.route ?? '--'}</DD>
             {swap.isServiceRunning && (
               <>
-                <DT>{t('SPONSOR_TRANSACTION')}</DT>
-                <ToggleContainer>
-                  <CustomSwitch
-                    onColor={theme.colors.purple_main}
-                    offColor={theme.colors.background.elevation3}
-                    onChange={swap.toggleUserOverrideSponsorValue}
-                    checked={swap.isSponsored}
-                    uncheckedIcon={false}
-                    checkedIcon={false}
-                    height={19}
-                    width={36}
-                  />
-                </ToggleContainer>
+                <>
+                  <SponsorTransactionSwitchLabel disabled={swap.isSponsorDisabled}>
+                    {t('SPONSOR_TRANSACTION')}
+                  </SponsorTransactionSwitchLabel>
+                  <ToggleContainer>
+                    <CustomSwitch
+                      onColor={theme.colors.purple_main}
+                      offColor={theme.colors.background.elevation3}
+                      onChange={swap.handleChangeUserOverrideSponsorValue}
+                      checked={swap.isSponsored}
+                      disabled={swap.isSponsorDisabled}
+                      uncheckedIcon={false}
+                      checkedIcon={false}
+                      height={19}
+                      width={36}
+                    />
+                  </ToggleContainer>
+                </>
+                {swap.isSponsorDisabled && (
+                  <div>
+                    <CannotBeSponsored>
+                      {t('SWAP_TRANSACTION_CANNOT_BE_SPONSORED')}
+                    </CannotBeSponsored>
+                    <LearnMoreAnchor
+                      href={SWAP_SPONSOR_DISABLED_SUPPORT_URL}
+                      target={SUPPORT_URL_TAB_TARGET}
+                      rel="noopener noreferrer"
+                    >
+                      {t('LEARN_MORE')}
+                      {' →'}
+                    </LearnMoreAnchor>
+                  </div>
+                )}
               </>
             )}
           </>

--- a/src/app/screens/swap/useAlexSponsoredTransaction.ts
+++ b/src/app/screens/swap/useAlexSponsoredTransaction.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { StacksTransaction } from '@secretkeylabs/xverse-core';
 import { AlexSDK } from 'alex-sdk';
+import useStxPendingTxData from '@hooks/queries/useStxPendingTxData';
 
 const useAlexSponsorSwapEnabledQuery = (alexSDK: AlexSDK) =>
   useQuery({
@@ -23,10 +24,14 @@ export const useAlexSponsoredTransaction = (userOverrideSponsorValue: boolean) =
   const sponsorTransaction = async (signed: StacksTransaction) =>
     alexSDK.broadcastSponsoredTx(signed.serialize().toString('hex'));
 
+  const { data: stxPendingTxData } = useStxPendingTxData();
+  const hasPendingTransactions = stxPendingTxData?.pendingTransactions?.length > 0;
+
   return {
-    isSponsored: userOverrideSponsorValue && isServiceRunning,
+    isSponsored: userOverrideSponsorValue && isServiceRunning && !hasPendingTransactions,
     isServiceRunning,
     sponsorTransaction,
+    isSponsorDisabled: hasPendingTransactions,
   };
 };
 

--- a/src/app/screens/swap/useSwap.tsx
+++ b/src/app/screens/swap/useSwap.tsx
@@ -55,7 +55,8 @@ export type UseSwap = {
   onSwap?: () => Promise<void>;
   isSponsored: boolean;
   isServiceRunning: boolean;
-  toggleUserOverrideSponsorValue: () => void;
+  handleChangeUserOverrideSponsorValue: (checked: boolean) => void;
+  isSponsorDisabled: boolean;
 };
 
 export type SelectedCurrencyState = {
@@ -129,8 +130,9 @@ export function useSwap(): UseSwap {
     stxPublicKey,
   } = useWalletSelector();
   const [userOverrideSponsorValue, setUserOverrideSponsorValue] = useState(true);
-  const { isSponsored, isServiceRunning } = useAlexSponsoredTransaction(userOverrideSponsorValue);
   const { data: stxPendingTxData } = useStxPendingTxData();
+  const { isSponsored, isServiceRunning, isSponsorDisabled } =
+    useAlexSponsoredTransaction(userOverrideSponsorValue);
 
   const acceptableCoinList = supportedCoins
     .filter((sc) => alexSDK.getCurrencyFrom(sc.contract) != null)
@@ -391,8 +393,9 @@ export function useSwap(): UseSwap {
         : undefined,
     isSponsored,
     isServiceRunning,
-    toggleUserOverrideSponsorValue: () => {
-      setUserOverrideSponsorValue((prevValue) => !prevValue);
+    handleChangeUserOverrideSponsorValue: (checked: boolean) => {
+      setUserOverrideSponsorValue(checked);
     },
+    isSponsorDisabled,
   };
 }

--- a/src/app/utils/constants.ts
+++ b/src/app/utils/constants.ts
@@ -56,7 +56,6 @@ export const initialNetworksList: SettingsNetwork[] = [
 export const SEND_MANY_TOKEN_TRANSFER_CONTRACT_PRINCIPAL =
   'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.send-many-memo';
 
-// TODO tim: edit placeholder once article is published
 export const SWAP_SPONSOR_DISABLED_SUPPORT_URL =
-  'https://support.xverse.app/hc/en-us/categories/17760950126733-Pending-Transactions';
+  'https://support.xverse.app/hc/en-us/articles/18319388355981';
 export const SUPPORT_URL_TAB_TARGET = 'SupportURLTabTarget';

--- a/src/app/utils/constants.ts
+++ b/src/app/utils/constants.ts
@@ -55,3 +55,8 @@ export const initialNetworksList: SettingsNetwork[] = [
  */
 export const SEND_MANY_TOKEN_TRANSFER_CONTRACT_PRINCIPAL =
   'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.send-many-memo';
+
+// TODO tim: edit placeholder once article is published
+export const SWAP_SPONSOR_DISABLED_SUPPORT_URL =
+  'https://support.xverse.app/hc/en-us/categories/17760950126733-Pending-Transactions';
+export const SUPPORT_URL_TAB_TARGET = 'SupportURLTabTarget';

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -802,7 +802,9 @@
       "INVALID_AMOUNT": "Invalid amount",
       "INSUFFICIENT_BALANCE_FEES": "Insufficient balance",
       "SLIPPAGE_TOLERANCE_CANNOT_EXCEED": "The slippage tolerance cannot exceed 100%"
-    }
+    },
+    "SWAP_TRANSACTION_CANNOT_BE_SPONSORED": "Swap transaction cannot be sponsored while you have a pending transaction.",
+    "LEARN_MORE": "Learn more"
   },
   "SWAP_CONFIRM_SCREEN": {
     "TOKEN_SWAP": "Token swap",
@@ -821,6 +823,8 @@
     "COPIED": "Copied",
     "COPY_YOUR_ADDRESS": "copy your address",
     "ADVANCED_SETTING": "Advanced settings",
-    "THIS_IS_A_SPONSORED_TRANSACTION": "This is a sponsored transaction, no transaction fees will be deducted from your account."
+    "THIS_IS_A_SPONSORED_TRANSACTION": "This is a sponsored transaction, no transaction fees will be deducted from your account.",
+    "SWAP_TRANSACTION_CANNOT_BE_SPONSORED": "Swap transaction cannot be sponsored while you have a pending transaction.",
+    "LEARN_MORE": "Learn more"
   }
 }


### PR DESCRIPTION
# 🔘 PR Type

- [x] Enhancement

# 📜 Background
Issue Link: https://linear.app/xverseapp/issue/ENG-2572/add-warning-texts-to-explain-why-a-swap-cannot-be-sponsored 
Context Link (if applicable):

# 🔄 Changes
- add a warning text to swap page if sponsor service is disabled
- add a warning box to swap confirm page if sponsor service is disabled
- add logic to disable using alex sponsor service if we see selected account has pending stacks transactions

Impact:
- swaps

# 🖼 Screenshot / 📹 Video
not disabled:
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/2e50751a-f5da-42ca-86eb-7632f099c63b)

has pending transactions swap screen:
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/5ac3e58f-cc16-414e-9dca-d09ad4285069)

has pending transactions swap confirm screen:
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/95e7e29a-9359-4cb6-88c1-f4e4a5a625b8)

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
