### PR TITLE
fix: swap token number input should not overflow

### DIFF
--- a/src/app/screens/swap/swapTokenBlock/index.tsx
+++ b/src/app/screens/swap/swapTokenBlock/index.tsx
@@ -83,6 +83,7 @@ export const AmountInput = styled(NumberInput)<{ error?: boolean }>((props) => (
   textAlign: 'right',
   backgroundColor: 'transparent',
   border: 'transparent',
+  width: '100%',
 }));
 
 const CoinText = styled.div((props) => ({


### PR DESCRIPTION
# 🔘 PR Type

- [x] Bugfix

# 📜 Background
Issue Link: https://linear.app/xverseapp/issue/ENG-2570/missing-padding-when-the-digits-are-longer 
Context Link (if applicable):

# 🔄 Changes
- styling on swap screen

Impact:
- swap screen UI only

# 🖼 Screenshot / 📹 Video
with update:
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/30e92228-e91e-4e40-bb44-9dda6fe80b3b)


# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
