### PR TITLE
Fix swap screen fee update issue

### DIFF
--- a/src/app/screens/swap/swapConfirmation/advanceSettings/index.tsx
+++ b/src/app/screens/swap/swapConfirmation/advanceSettings/index.tsx
@@ -40,7 +40,7 @@ export function AdvanceSettings({ swap }: Props) {
 
   const onApplyClick = useCallback(({ fee, nonce }: { fee: string; nonce?: string }) => {
     const settingFee = BigInt(stxToMicrostacks(new BigNumber(fee) as any).toString());
-    swap.unsignedTx.setFee(settingFee);
+    swap.onFeeUpdate(settingFee);
     if (nonce != null) {
       swap.unsignedTx.setNonce(BigInt(nonce));
     }

--- a/src/app/screens/swap/swapConfirmation/index.tsx
+++ b/src/app/screens/swap/swapConfirmation/index.tsx
@@ -81,11 +81,13 @@ export default function SwapConfirmation() {
         <StxInfoBlock type="receive" swap={swap} />
         <FunctionBlock name={swap.functionName} />
         <RouteBlock swap={swap} />
-        <FeesBlock
-          lpFee={swap.lpFeeAmount}
-          lpFeeFiatAmount={swap.lpFeeFiatAmount}
-          currency={swap.fromToken.name}
-        />
+        {!isSponsored && (
+          <FeesBlock
+            lpFee={swap.lpFeeAmount}
+            lpFeeFiatAmount={swap.lpFeeFiatAmount}
+            currency={swap.fromToken.name}
+          />
+        )}
         {isSponsored ? (
           <SponsoredTransactionText>
             <Icon src={SponsoredTransactionIcon} />

--- a/src/app/screens/swap/swapConfirmation/useConfirmSwap.tsx
+++ b/src/app/screens/swap/swapConfirmation/useConfirmSwap.tsx
@@ -2,6 +2,7 @@ import { Currency, SponsoredTxErrorCode, SponsoredTxError } from 'alex-sdk';
 import { useNavigate } from 'react-router-dom';
 import { SwapToken } from '@screens/swap/useSwap';
 import useWalletSelector from '@hooks/useWalletSelector';
+import { microstacksToStx } from '@secretkeylabs/xverse-core';
 import {
   broadcastSignedTransaction,
   signTransaction,
@@ -12,6 +13,9 @@ import useNetworkSelector from '@hooks/useNetwork';
 import { ApiResponseError } from '@secretkeylabs/xverse-core/types';
 import { TokenImageProps } from '@components/tokenImage';
 import { useAlexSponsoredTransaction } from '../useAlexSponsoredTransaction';
+import { useState } from 'react';
+import BigNumber from 'bignumber.js';
+import { useCurrencyConversion } from '../useCurrencyConversion';
 
 export type SwapConfirmationInput = {
   from: Currency;
@@ -31,6 +35,7 @@ export type SwapConfirmationInput = {
 
 export type SwapConfirmationOutput = Omit<SwapConfirmationInput, 'unsignedTx'> & {
   onConfirm: () => Promise<void>;
+  onFeeUpdate: (settingFee: bigint) => void;
   unsignedTx: StacksTransaction; // deserialized StacksTransaction
 };
 
@@ -40,15 +45,27 @@ export function useConfirmSwap(input: SwapConfirmationInput): SwapConfirmationOu
   const { isSponsored, sponsorTransaction } = useAlexSponsoredTransaction(
     input.userOverrideSponsorValue,
   );
+  const { currencyToToken } = useCurrencyConversion();
   const navigate = useNavigate();
-  const unsignedTx = deserializeTransaction(input.unsignedTx);
+  const [unsignedTx, setUnsignedTx] = useState<StacksTransaction>(
+    deserializeTransaction(input.unsignedTx),
+  );
+  const [feeAmount, setFeeAmount] = useState(input.lpFeeAmount);
+  const [feeFiatAmount, setFeeFiatAmount] = useState(input.lpFeeFiatAmount);
 
   return {
     ...input,
-    lpFeeAmount: isSponsored ? 0 : input.lpFeeAmount,
-    lpFeeFiatAmount: isSponsored ? 0 : input.lpFeeFiatAmount,
+    lpFeeAmount: isSponsored ? 0 : feeAmount,
+    lpFeeFiatAmount: isSponsored ? 0 : feeFiatAmount,
     unsignedTx,
     userOverrideSponsorValue: input.userOverrideSponsorValue,
+    onFeeUpdate: (settingFee: bigint) => {
+      const fee = microstacksToStx(new BigNumber(settingFee));
+      unsignedTx.setFee(settingFee);
+      setUnsignedTx(unsignedTx);
+      setFeeAmount(Number(fee));
+      setFeeFiatAmount(currencyToToken(input.from, Number(fee))?.fiatAmount);
+    },
     onConfirm: async () => {
       const signed = await signTransaction(
         unsignedTx,

--- a/src/app/screens/swap/useCurrencyConversion.tsx
+++ b/src/app/screens/swap/useCurrencyConversion.tsx
@@ -1,0 +1,75 @@
+import useWalletSelector from '@hooks/useWalletSelector';
+import { FungibleToken, getFiatEquivalent, microstacksToStx } from '@secretkeylabs/xverse-core';
+import { LoaderSize } from '@utils/constants';
+import { ftDecimals } from '@utils/helper';
+import { AlexSDK, Currency } from 'alex-sdk';
+import BigNumber from 'bignumber.js';
+import { SwapToken } from './useSwap';
+
+export function useCurrencyConversion() {
+  const alexSDK = new AlexSDK();
+  const {
+    coins: supportedCoins = [],
+    coinsList: visibleCoins = [],
+    stxAvailableBalance,
+    stxBtcRate,
+    btcFiatRate,
+  } = useWalletSelector();
+
+  const acceptableCoinList = supportedCoins
+    .filter((sc) => alexSDK.getCurrencyFrom(sc.contract) != null)
+    // TODO tim: remove this once alexsdk fix issue here
+    // https://github.com/alexgo-io/alex-sdk/issues/2
+    .filter((sc) => sc.contract !== 'SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.brc20-db20')
+    .map<FungibleToken>((sc) => {
+      const ft = (visibleCoins || []).find((vc) => vc.principal === sc.contract);
+      return {
+        ...ft,
+        ...sc,
+        principal: sc.contract,
+        assetName: '',
+        total_sent: ft?.total_sent ?? '0',
+        total_received: ft?.total_received ?? '0',
+        balance: ft?.balance ?? '0',
+      };
+    });
+
+  function currencyToToken(currency?: Currency, amount?: number): SwapToken | undefined {
+    if (currency == null) {
+      return undefined;
+    }
+    if (currency === Currency.STX) {
+      return {
+        balance: Number(microstacksToStx(BigNumber(stxAvailableBalance) as any)),
+        image: { token: 'STX', size: 28, loaderSize: LoaderSize.SMALL },
+        name: 'STX',
+        amount,
+        fiatAmount:
+          amount != null
+            ? Number(getFiatEquivalent(amount, 'STX', stxBtcRate as any, btcFiatRate as any))
+            : undefined,
+      };
+    }
+    const token = acceptableCoinList.find(
+      (c) => alexSDK.getCurrencyFrom(c.principal) === currency,
+    )!;
+    if (token == null) {
+      return undefined;
+    }
+    return {
+      amount,
+      image: { fungibleToken: token, size: 28, loaderSize: LoaderSize.SMALL },
+      name: (token.ticker ?? token.name).toUpperCase(),
+      balance: Number(ftDecimals(token.balance, token.decimals ?? 0)),
+      fiatAmount:
+        amount != null
+          ? Number(getFiatEquivalent(amount, 'FT', stxBtcRate as any, btcFiatRate as any, token))
+          : undefined,
+    };
+  }
+
+  return {
+    acceptableCoinList,
+    currencyToToken,
+  };
+}

--- a/src/app/screens/swap/useSwap.tsx
+++ b/src/app/screens/swap/useSwap.tsx
@@ -9,16 +9,14 @@ import {
 import { useTranslation } from 'react-i18next';
 import useWalletSelector from '@hooks/useWalletSelector';
 import { TokenImageProps } from '@components/tokenImage';
-import { LoaderSize } from '@utils/constants';
 import { AlexSDK, Currency } from 'alex-sdk';
-import { ftDecimals } from '@utils/helper';
 import BigNumber from 'bignumber.js';
-import { getFiatEquivalent } from '@secretkeylabs/xverse-core/transactions';
 import { useNavigate } from 'react-router-dom';
 import { SwapConfirmationInput } from '@screens/swap/swapConfirmation/useConfirmSwap';
 import { AnchorMode, makeUnsignedContractCall, PostConditionMode } from '@stacks/transactions';
 import useStxPendingTxData from '@hooks/queries/useStxPendingTxData';
 import { useAlexSponsoredTransaction } from './useAlexSponsoredTransaction';
+import { useCurrencyConversion } from './useCurrencyConversion';
 
 const isNotNull = <T extends any>(t: T | null | undefined): t is T => t != null;
 
@@ -119,36 +117,11 @@ export function useSwap(): UseSwap {
   const navigate = useNavigate();
   const alexSDK = useState(() => new AlexSDK())[0];
   const { t } = useTranslation('translation', { keyPrefix: 'SWAP_SCREEN' });
-  const {
-    coins: supportedCoins = [],
-    coinsList: visibleCoins = [],
-    stxAvailableBalance,
-    stxBtcRate,
-    btcFiatRate,
-    stxAddress,
-    stxPublicKey,
-  } = useWalletSelector();
+  const { stxAddress, stxPublicKey } = useWalletSelector();
+  const { acceptableCoinList, currencyToToken } = useCurrencyConversion();
   const [userOverrideSponsorValue, setUserOverrideSponsorValue] = useState(true);
   const { isSponsored, isServiceRunning } = useAlexSponsoredTransaction(userOverrideSponsorValue);
   const { data: stxPendingTxData } = useStxPendingTxData();
-
-  const acceptableCoinList = supportedCoins
-    .filter((sc) => alexSDK.getCurrencyFrom(sc.contract) != null)
-    // TODO tim: remove this once alexsdk fix issue here
-    // https://github.com/alexgo-io/alex-sdk/issues/2
-    .filter((sc) => sc.contract !== 'SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.brc20-db20')
-    .map<FungibleToken>((sc) => {
-      const ft = (visibleCoins || []).find((vc) => vc.principal === sc.contract);
-      return {
-        ...ft,
-        ...sc,
-        principal: sc.contract,
-        assetName: '',
-        total_sent: ft?.total_sent ?? '0',
-        total_received: ft?.total_received ?? '0',
-        balance: ft?.balance ?? '0',
-      };
-    });
 
   const [inputAmount, setInputAmount] = useState('');
   const [slippage, setSlippage] = useState(0.04);
@@ -160,40 +133,6 @@ export function useSwap(): UseSwap {
   });
 
   const fromAmount = Number.isNaN(Number(inputAmount)) ? undefined : Number(inputAmount);
-
-  function currencyToToken(currency?: Currency, amount?: number): SwapToken | undefined {
-    if (currency == null) {
-      return undefined;
-    }
-    if (currency === Currency.STX) {
-      return {
-        balance: Number(microstacksToStx(BigNumber(stxAvailableBalance) as any)),
-        image: { token: 'STX', size: 28, loaderSize: LoaderSize.SMALL },
-        name: 'STX',
-        amount,
-        fiatAmount:
-          amount != null
-            ? Number(getFiatEquivalent(amount, 'STX', stxBtcRate as any, btcFiatRate as any))
-            : undefined,
-      };
-    }
-    const token = acceptableCoinList.find(
-      (c) => alexSDK.getCurrencyFrom(c.principal) === currency,
-    )!;
-    if (token == null) {
-      return undefined;
-    }
-    return {
-      amount,
-      image: { fungibleToken: token, size: 28, loaderSize: LoaderSize.SMALL },
-      name: (token.ticker ?? token.name).toUpperCase(),
-      balance: Number(ftDecimals(token.balance, token.decimals ?? 0)),
-      fiatAmount:
-        amount != null
-          ? Number(getFiatEquivalent(amount, 'FT', stxBtcRate as any, btcFiatRate as any, token))
-          : undefined,
-    };
-  }
 
   function getCurrencyName(currency: Currency) {
     if (currency === Currency.STX) {

--- a/src/app/screens/swap/useSwap.tsx
+++ b/src/app/screens/swap/useSwap.tsx
@@ -367,7 +367,9 @@ export function useSwap(): UseSwap {
               unsignedTx,
               getNewNonce(stxPendingTxData?.pendingTransactions || [], getNonce(unsignedTx)),
             );
-
+            const fee = microstacksToStx(
+              new BigNumber(unsignedTx.auth.spendingCondition.fee.toString()),
+            ).toNumber();
             const state: SwapConfirmationInput = {
               from: selectedCurrency.from!,
               to: selectedCurrency.to!,
@@ -376,9 +378,8 @@ export function useSwap(): UseSwap {
               address: stxAddress,
               fromAmount: fromAmount!,
               minToAmount: toAmount! * (1 - slippage),
-              lpFeeAmount: info.feeRate * fromAmount!,
-              lpFeeFiatAmount: currencyToToken(selectedCurrency.from!, info.feeRate * fromAmount!)
-                ?.fiatAmount,
+              lpFeeAmount: fee,
+              lpFeeFiatAmount: currencyToToken(selectedCurrency.from!, fee)?.fiatAmount,
               routers: info.route.map(currencyToToken).filter(isNotNull),
               unsignedTx: unsignedTx.serialize().toString('hex'),
               functionName: `${tx.contractName}\n${tx.functionName}`,


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background
The correct fee value was not being displayed in the fee card of the stacks confirmation screen. 
The fee is not updating according to user's settings. if the user chooses to not use sponsored transaction for swapping then the value is not reflected in the ui neither in the stx transaction object. There was an issue with state update

Issue Link: [#[ENG-2569]](https://linear.app/xverseapp/issue/ENG-2569/fee-is-not-being-updated-on-ui)

# 🔄 Changes
-The state management is updated so change of fees is reflected.  `onFeeUpdate` function is added in the `useConfirmSwap` . 
- The `useCurrencyConversion` hook is introduced which separates the function `currencyToToken` to be used in different screens. 
- Instead of showing the `lpFeeAmount` in the fee component, the fee is shown  from the unsigned transaction object
- The fee block is not shown if the transaction is sponsored

# 🖼 Screenshot / 📹 Video


<img width="432" alt="sponsored-tx" src="https://github.com/secretkeylabs/xverse-web-extension/assets/88320460/5c56776e-0369-4a9f-bcc3-05c8d7d739b6">




https://github.com/secretkeylabs/xverse-web-extension/assets/88320460/73a1b706-5c9c-4228-a968-8f088880a552



# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
