### PR TITLE
Fix swaps tx history

### DIFF
--- a/src/app/components/transactions/stxTransaction.tsx
+++ b/src/app/components/transactions/stxTransaction.tsx
@@ -30,10 +30,11 @@ import StxTransferTransaction from './stxTransferTransaction';
 interface TransactionHistoryItemProps {
   transaction: AddressTransactionWithTransfers | Tx;
   transactionCoin: CurrencyTypes;
+  txFilter: string | null;
 }
 
 export default function StxTransactionHistoryItem(props: TransactionHistoryItemProps) {
-  const { transaction, transactionCoin } = props;
+  const { transaction, transactionCoin, txFilter } = props;
   const { selectedAccount } = useWalletSelector();
   // const { t } = useTranslation('translation', { keyPrefix: 'COIN_DASHBOARD_SCREEN' });
   if (!isAddressTransactionWithTransfers(transaction)) {
@@ -68,7 +69,7 @@ export default function StxTransactionHistoryItem(props: TransactionHistoryItemP
   }
   return (
     <>
-      <TxTransfers transaction={transaction} coin={transactionCoin} />
+      <TxTransfers transaction={transaction} coin={transactionCoin} txFilter={txFilter} />
       <StxTransferTransaction
         transaction={parseStxTransactionData({
           responseTx: transaction.tx,

--- a/src/app/components/transactions/txTransfers.tsx
+++ b/src/app/components/transactions/txTransfers.tsx
@@ -9,6 +9,7 @@ import { NumericFormat } from 'react-number-format';
 import { microstacksToStx } from '@secretkeylabs/xverse-core';
 import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
+import { getFtTicker } from '@utils/tokens';
 
 const TransactionContainer = styled.div((props) => ({
   display: 'flex',
@@ -56,7 +57,7 @@ interface TxTransfersProps {
 
 export default function TxTransfers(props: TxTransfersProps) {
   const { transaction, coin, txFilter } = props;
-  const { selectedAccount } = useWalletSelector();
+  const { selectedAccount, coinsList } = useWalletSelector();
   const { t } = useTranslation('translation', { keyPrefix: 'COIN_DASHBOARD_SCREEN' });
 
   function formatAddress(addr: string): string {
@@ -78,8 +79,8 @@ export default function TxTransfers(props: TxTransfersProps) {
   function renderTransaction(transactionList) {
     return transactionList.map((transfer) => {
       const isFT = coin === 'FT';
+      const ft = coinsList?.find((ftCoin) => ftCoin.principal === txFilter!.split('::')[0]);
       const isRecipientNegative = selectedAccount?.stxAddress !== transfer.recipient;
-
       if (isFT && transfer.asset_identifier !== txFilter) {
         return null;
       }
@@ -97,9 +98,7 @@ export default function TxTransfers(props: TxTransfersProps) {
                 prefix={isRecipientNegative ? '-' : ''}
                 renderText={(value: string) => (
                   <TransactionValue>
-                    {`${value} ${
-                      isFT ? transfer.asset_identifier.split('::')[1].toUpperCase() : coin
-                    }`}
+                    {`${value} ${isFT && ft ? getFtTicker(ft) : coin}`}
                   </TransactionValue>
                 )}
               />

--- a/src/app/components/transactions/txTransfers.tsx
+++ b/src/app/components/transactions/txTransfers.tsx
@@ -80,7 +80,7 @@ export default function TxTransfers(props: TxTransfersProps) {
     return transactionList.map((transfer) => {
       const isFT = coin === 'FT';
       const ft = coinsList?.find((ftCoin) => ftCoin.principal === txFilter!.split('::')[0]);
-      const isRecipientNegative = selectedAccount?.stxAddress !== transfer.recipient;
+      const isSentTransaction = selectedAccount?.stxAddress !== transfer.recipient;
       if (isFT && transfer.asset_identifier !== txFilter) {
         return null;
       }
@@ -95,7 +95,7 @@ export default function TxTransfers(props: TxTransfersProps) {
                 value={microstacksToStx(BigNumber(transfer.amount)).toString()}
                 displayType="text"
                 thousandSeparator
-                prefix={isRecipientNegative ? '-' : ''}
+                prefix={isSentTransaction ? '-' : ''}
                 renderText={(value: string) => (
                   <TransactionValue>
                     {`${value} ${isFT && ft ? getFtTicker(ft) : coin}`}

--- a/src/app/components/transactions/txTransfers.tsx
+++ b/src/app/components/transactions/txTransfers.tsx
@@ -74,61 +74,47 @@ export default function TxTransfers(props: TxTransfersProps) {
     selectedAccount?.stxAddress === transfer.recipient
       ? t('TRANSACTION_RECEIVED')
       : t('TRANSACTION_SENT');
+
+  function renderTransaction(transactionList) {
+    return transactionList.map((transfer) => {
+      const isFT = coin === 'FT';
+      const isRecipientNegative = selectedAccount?.stxAddress !== transfer.recipient;
+
+      if (isFT && transfer.asset_identifier !== txFilter) {
+        return null;
+      }
+
+      return (
+        <TransactionContainer key={nanoid()}>
+          {renderTransactionIcon(transfer)}
+          <TransactionInfoContainer>
+            <TransactionRow>
+              <TransactionTitleText>{getTokenTransferTitle(transfer)}</TransactionTitleText>
+              <NumericFormat
+                value={microstacksToStx(BigNumber(transfer.amount)).toString()}
+                displayType="text"
+                thousandSeparator
+                prefix={isRecipientNegative ? '-' : ''}
+                renderText={(value: string) => (
+                  <TransactionValue>
+                    {`${value} ${
+                      isFT ? transfer.asset_identifier.split('::')[1].toUpperCase() : coin
+                    }`}
+                  </TransactionValue>
+                )}
+              />
+            </TransactionRow>
+            <RecipientAddress>{formatAddress(transfer.recipient as string)}</RecipientAddress>
+          </TransactionInfoContainer>
+        </TransactionContainer>
+      );
+    });
+  }
   return (
     <>
       {coin === 'FT' && transaction.ft_transfers
-        ? transaction.ft_transfers.map((ftTransfer) => {
-            if (ftTransfer.asset_identifier === txFilter) {
-              return (
-                <TransactionContainer key={nanoid()}>
-                  {renderTransactionIcon(ftTransfer)}
-                  <TransactionInfoContainer>
-                    <TransactionRow>
-                      <TransactionTitleText>
-                        {getTokenTransferTitle(ftTransfer)}
-                      </TransactionTitleText>
-                      <NumericFormat
-                        value={microstacksToStx(BigNumber(ftTransfer.amount)).toString()}
-                        displayType="text"
-                        thousandSeparator
-                        prefix={selectedAccount?.stxAddress === ftTransfer.recipient ? '' : '-'}
-                        renderText={(value: string) => (
-                          <TransactionValue>{`${value} ${ftTransfer.asset_identifier
-                            .split('::')[1]
-                            .toUpperCase()}`}</TransactionValue>
-                        )}
-                      />
-                    </TransactionRow>
-                    <RecipientAddress>
-                      {formatAddress(ftTransfer.recipient as string)}
-                    </RecipientAddress>
-                  </TransactionInfoContainer>
-                </TransactionContainer>
-              );
-            }
-          })
-        : transaction.stx_transfers.map((stxTransfer) => (
-            <TransactionContainer key={nanoid()}>
-              {renderTransactionIcon(stxTransfer)}
-              <TransactionInfoContainer>
-                <TransactionRow>
-                  <TransactionTitleText>{getTokenTransferTitle(stxTransfer)}</TransactionTitleText>
-                  <NumericFormat
-                    value={microstacksToStx(BigNumber(stxTransfer.amount)).toString()}
-                    displayType="text"
-                    thousandSeparator
-                    prefix={selectedAccount?.stxAddress === stxTransfer.recipient ? '' : '-'}
-                    renderText={(value: string) => (
-                      <TransactionValue>{`${value} ${coin}`}</TransactionValue>
-                    )}
-                  />
-                </TransactionRow>
-                <RecipientAddress>
-                  {formatAddress(stxTransfer.recipient as string)}
-                </RecipientAddress>
-              </TransactionInfoContainer>
-            </TransactionContainer>
-          ))}
+        ? renderTransaction(transaction.ft_transfers)
+        : renderTransaction(transaction.stx_transfers)}
     </>
   );
 }

--- a/src/app/components/transactions/txTransfers.tsx
+++ b/src/app/components/transactions/txTransfers.tsx
@@ -51,10 +51,11 @@ const TransactionValue = styled.p((props) => ({
 interface TxTransfersProps {
   transaction: AddressTransactionWithTransfers;
   coin: CurrencyTypes;
+  txFilter: string | null;
 }
 
 export default function TxTransfers(props: TxTransfersProps) {
-  const { transaction, coin } = props;
+  const { transaction, coin, txFilter } = props;
   const { selectedAccount } = useWalletSelector();
   const { t } = useTranslation('translation', { keyPrefix: 'COIN_DASHBOARD_SCREEN' });
 
@@ -76,28 +77,36 @@ export default function TxTransfers(props: TxTransfersProps) {
   return (
     <>
       {coin === 'FT' && transaction.ft_transfers
-        ? transaction.ft_transfers.map((ftTransfer) => (
-            <TransactionContainer key={nanoid()}>
-              {renderTransactionIcon(ftTransfer)}
-              <TransactionInfoContainer>
-                <TransactionRow>
-                  <TransactionTitleText>{getTokenTransferTitle(ftTransfer)}</TransactionTitleText>
-                  <NumericFormat
-                    value={microstacksToStx(BigNumber(ftTransfer.amount)).toString()}
-                    displayType="text"
-                    thousandSeparator
-                    prefix={selectedAccount?.stxAddress === ftTransfer.recipient ? '' : '-'}
-                    renderText={(value: string) => (
-                      <TransactionValue>{`${value} ${ftTransfer.asset_identifier
-                        .split('::')[1]
-                        .toUpperCase()}`}</TransactionValue>
-                    )}
-                  />
-                </TransactionRow>
-                <RecipientAddress>{formatAddress(ftTransfer.recipient as string)}</RecipientAddress>
-              </TransactionInfoContainer>
-            </TransactionContainer>
-          ))
+        ? transaction.ft_transfers.map((ftTransfer) => {
+            if (ftTransfer.asset_identifier === txFilter) {
+              return (
+                <TransactionContainer key={nanoid()}>
+                  {renderTransactionIcon(ftTransfer)}
+                  <TransactionInfoContainer>
+                    <TransactionRow>
+                      <TransactionTitleText>
+                        {getTokenTransferTitle(ftTransfer)}
+                      </TransactionTitleText>
+                      <NumericFormat
+                        value={microstacksToStx(BigNumber(ftTransfer.amount)).toString()}
+                        displayType="text"
+                        thousandSeparator
+                        prefix={selectedAccount?.stxAddress === ftTransfer.recipient ? '' : '-'}
+                        renderText={(value: string) => (
+                          <TransactionValue>{`${value} ${ftTransfer.asset_identifier
+                            .split('::')[1]
+                            .toUpperCase()}`}</TransactionValue>
+                        )}
+                      />
+                    </TransactionRow>
+                    <RecipientAddress>
+                      {formatAddress(ftTransfer.recipient as string)}
+                    </RecipientAddress>
+                  </TransactionInfoContainer>
+                </TransactionContainer>
+              );
+            }
+          })
         : transaction.stx_transfers.map((stxTransfer) => (
             <TransactionContainer key={nanoid()}>
               {renderTransactionIcon(stxTransfer)}

--- a/src/app/components/transactions/txTransfers.tsx
+++ b/src/app/components/transactions/txTransfers.tsx
@@ -75,26 +75,51 @@ export default function TxTransfers(props: TxTransfersProps) {
       : t('TRANSACTION_SENT');
   return (
     <>
-      {transaction.stx_transfers.map((stxTransfer) => (
-        <TransactionContainer key={nanoid()}>
-          {renderTransactionIcon(stxTransfer)}
-          <TransactionInfoContainer>
-            <TransactionRow>
-              <TransactionTitleText>{getTokenTransferTitle(stxTransfer)}</TransactionTitleText>
-              <NumericFormat
-                value={microstacksToStx(BigNumber(stxTransfer.amount)).toString()}
-                displayType="text"
-                thousandSeparator
-                prefix={selectedAccount?.stxAddress === stxTransfer.recipient ? '' : '-'}
-                renderText={(value: string) => (
-                  <TransactionValue>{`${value} ${coin}`}</TransactionValue>
-                )}
-              />
-            </TransactionRow>
-            <RecipientAddress>{formatAddress(stxTransfer.recipient as string)}</RecipientAddress>
-          </TransactionInfoContainer>
-        </TransactionContainer>
-      ))}
+      {coin === 'FT' && transaction.ft_transfers
+        ? transaction.ft_transfers.map((ftTransfer) => (
+            <TransactionContainer key={nanoid()}>
+              {renderTransactionIcon(ftTransfer)}
+              <TransactionInfoContainer>
+                <TransactionRow>
+                  <TransactionTitleText>{getTokenTransferTitle(ftTransfer)}</TransactionTitleText>
+                  <NumericFormat
+                    value={microstacksToStx(BigNumber(ftTransfer.amount)).toString()}
+                    displayType="text"
+                    thousandSeparator
+                    prefix={selectedAccount?.stxAddress === ftTransfer.recipient ? '' : '-'}
+                    renderText={(value: string) => (
+                      <TransactionValue>{`${value} ${ftTransfer.asset_identifier
+                        .split('::')[1]
+                        .toUpperCase()}`}</TransactionValue>
+                    )}
+                  />
+                </TransactionRow>
+                <RecipientAddress>{formatAddress(ftTransfer.recipient as string)}</RecipientAddress>
+              </TransactionInfoContainer>
+            </TransactionContainer>
+          ))
+        : transaction.stx_transfers.map((stxTransfer) => (
+            <TransactionContainer key={nanoid()}>
+              {renderTransactionIcon(stxTransfer)}
+              <TransactionInfoContainer>
+                <TransactionRow>
+                  <TransactionTitleText>{getTokenTransferTitle(stxTransfer)}</TransactionTitleText>
+                  <NumericFormat
+                    value={microstacksToStx(BigNumber(stxTransfer.amount)).toString()}
+                    displayType="text"
+                    thousandSeparator
+                    prefix={selectedAccount?.stxAddress === stxTransfer.recipient ? '' : '-'}
+                    renderText={(value: string) => (
+                      <TransactionValue>{`${value} ${coin}`}</TransactionValue>
+                    )}
+                  />
+                </TransactionRow>
+                <RecipientAddress>
+                  {formatAddress(stxTransfer.recipient as string)}
+                </RecipientAddress>
+              </TransactionInfoContainer>
+            </TransactionContainer>
+          ))}
     </>
   );
 }

--- a/src/app/screens/coinDashboard/transactionsHistoryList.tsx
+++ b/src/app/screens/coinDashboard/transactionsHistoryList.tsx
@@ -150,6 +150,8 @@ const filterTxs = (
 
 export default function TransactionsHistoryList(props: TransactionsHistoryListProps) {
   const { coin, txFilter } = props;
+  console.log('txFilter');
+  console.log(txFilter);
   const { data, isLoading, isFetching } = useTransactions((coin as CurrencyTypes) || 'STX');
   const styles = useSpring({
     config: { ...config.stiff },
@@ -171,6 +173,8 @@ export default function TransactionsHistoryList(props: TransactionsHistoryListPr
 
     if (txFilter && coin === 'FT') {
       const filteredTxs = filterTxs(data, txFilter);
+      console.log('filteredTxs');
+      console.log(filteredTxs);
       return groupedTxsByDateMap(filteredTxs);
     }
 

--- a/src/app/screens/coinDashboard/transactionsHistoryList.tsx
+++ b/src/app/screens/coinDashboard/transactionsHistoryList.tsx
@@ -150,8 +150,6 @@ const filterTxs = (
 
 export default function TransactionsHistoryList(props: TransactionsHistoryListProps) {
   const { coin, txFilter } = props;
-  console.log('txFilter');
-  console.log(txFilter);
   const { data, isLoading, isFetching } = useTransactions((coin as CurrencyTypes) || 'STX');
   const styles = useSpring({
     config: { ...config.stiff },
@@ -173,8 +171,6 @@ export default function TransactionsHistoryList(props: TransactionsHistoryListPr
 
     if (txFilter && coin === 'FT') {
       const filteredTxs = filterTxs(data, txFilter);
-      console.log('filteredTxs');
-      console.log(filteredTxs);
       return groupedTxsByDateMap(filteredTxs);
     }
 
@@ -204,6 +200,7 @@ export default function TransactionsHistoryList(props: TransactionsHistoryListPr
                   transaction={transaction}
                   transactionCoin={coin}
                   key={transaction.tx_id}
+                  txFilter={txFilter}
                 />
               );
             })}


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background
The correct transaction history for tokens after swap was not being shown 

Issue Link: #[[ENG-2584](https://linear.app/xverseapp/issue/ENG-2584/token-transaction-history-not-displayed-correctly-after-swap)]
Context Link (if applicable):

# 🔄 Changes
Currently we only go through the `stx_transfers` list. Now for fungible token we iterate over the `ft_transfers` list from the transaction object in the txTransfer component. 
Also uses the txFilter to only show the history of relevant token

# 🖼 Screenshot / 📹 Video

<img width="401" alt="fixed" src="https://github.com/secretkeylabs/xverse-web-extension/assets/88320460/6d04b975-5f7b-4513-9ba6-c25ad7eda3a0">

<img width="393" alt="fixed-2" src="https://github.com/secretkeylabs/xverse-web-extension/assets/88320460/26eb6897-144b-473c-a54d-912c5098b939">



# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
