### PR TITLE
fix: Don't use ordinals as inputs when recovering ordinals

### DIFF
--- a/src/app/screens/confirmOrdinalTransaction/index.tsx
+++ b/src/app/screens/confirmOrdinalTransaction/index.tsx
@@ -1,21 +1,21 @@
-import { useTranslation } from 'react-i18next';
-import styled from 'styled-components';
-import { useMutation } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import BottomBar from '@components/tabBar';
-import useNftDataSelector from '@hooks/stores/useNftDataSelector';
 import AccountHeaderComponent from '@components/accountHeader';
 import ConfirmBtcTransactionComponent from '@components/confirmBtcTransactionComponent';
-import { BtcTransactionBroadcastResponse } from '@secretkeylabs/xverse-core/types';
-import OrdinalImage from '@screens/ordinals/ordinalImage';
-import BigNumber from 'bignumber.js';
+import BottomBar from '@components/tabBar';
 import useBtcWalletData from '@hooks/queries/useBtcWalletData';
+import useNftDataSelector from '@hooks/stores/useNftDataSelector';
 import useBtcClient from '@hooks/useBtcClient';
-import { isLedgerAccount } from '@utils/helper';
+import { useResetUserFlow } from '@hooks/useResetUserFlow';
 import useWalletSelector from '@hooks/useWalletSelector';
 import { LedgerTransactionType } from '@screens/ledger/confirmLedgerTransaction';
-import { useResetUserFlow } from '@hooks/useResetUserFlow';
+import OrdinalImage from '@screens/ordinals/ordinalImage';
+import { BtcTransactionBroadcastResponse } from '@secretkeylabs/xverse-core/types';
+import { useMutation } from '@tanstack/react-query';
+import { isLedgerAccount } from '@utils/helper';
+import BigNumber from 'bignumber.js';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 
 const ScrollContainer = styled.div`
   display: flex;
@@ -184,7 +184,6 @@ function ConfirmOrdinalTransaction() {
       )}
       <ScrollContainer>
         <ConfirmBtcTransactionComponent
-          fee={fee}
           feePerVByte={feePerVByte}
           recipients={[{ address: recipientAddress, amountSats: new BigNumber(0) }]}
           loadingBroadcastedTx={isLoading}

--- a/src/app/screens/restoreFunds/restoreOrdinals/index.tsx
+++ b/src/app/screens/restoreFunds/restoreOrdinals/index.tsx
@@ -1,21 +1,21 @@
-import { useMutation } from '@tanstack/react-query';
-import { useEffect, useMemo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { BtcOrdinal, ErrorCodes, Inscription } from '@secretkeylabs/xverse-core/types';
+import ActionButton from '@components/button';
+import BottomTabBar from '@components/tabBar';
+import TopRow from '@components/topRow';
+import useOrdinalDataReducer from '@hooks/stores/useOrdinalReducer';
+import useOrdinalsByAddress from '@hooks/useOrdinalsByAddress';
+import useWalletSelector from '@hooks/useWalletSelector';
 import { getBtcFiatEquivalent } from '@secretkeylabs/xverse-core/currency';
 import {
   SignedBtcTx,
   signOrdinalSendTransaction,
 } from '@secretkeylabs/xverse-core/transactions/btc';
-import useWalletSelector from '@hooks/useWalletSelector';
-import useOrdinalsByAddress from '@hooks/useOrdinalsByAddress';
-import useOrdinalDataReducer from '@hooks/stores/useOrdinalReducer';
-import TopRow from '@components/topRow';
+import { BtcOrdinal, ErrorCodes, Inscription } from '@secretkeylabs/xverse-core/types';
+import { useMutation } from '@tanstack/react-query';
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import ActionButton from '@components/button';
-import BottomTabBar from '@components/tabBar';
-import OrdinalRow from './oridnalRow';
+import OrdinalRow from './ordinalRow';
 
 const RestoreFundTitle = styled.h1((props) => ({
   ...props.theme.body_l,
@@ -59,6 +59,7 @@ function RestoreOrdinals() {
   const navigate = useNavigate();
   const { ordinals } = useOrdinalsByAddress(btcAddress);
   const [error, setError] = useState('');
+  const [transferringOrdinalId, setTransferringOrdinalId] = useState<string | null>(null);
   const location = useLocation();
   const isRestoreFundFlow = location.state?.isRestoreFundFlow;
 
@@ -102,6 +103,8 @@ function RestoreOrdinals() {
   };
 
   const onClickTransfer = async (selectedOrdinal: BtcOrdinal, ordinalData: Inscription) => {
+    setTransferringOrdinalId(selectedOrdinal.id);
+
     const signedTx = await mutateAsync(selectedOrdinal);
     setSelectedOrdinalDetails(ordinalData);
     navigate(`/confirm-ordinal-tx/${selectedOrdinal.id}`, {
@@ -134,7 +137,8 @@ function RestoreOrdinals() {
             <RestoreFundTitle>{t('RESTORE_ORDINAL_SCREEN.DESCRIPTION')}</RestoreFundTitle>
             {ordinals?.map((ordinal) => (
               <OrdinalRow
-                isLoading={isLoading}
+                isLoading={transferringOrdinalId === ordinal.id}
+                disableTransfer={isLoading}
                 handleOrdinalTransfer={onClickTransfer}
                 ordinal={ordinal}
                 key={ordinal.id}

--- a/src/app/screens/restoreFunds/restoreOrdinals/ordinalRow.tsx
+++ b/src/app/screens/restoreFunds/restoreOrdinals/ordinalRow.tsx
@@ -1,9 +1,9 @@
-import styled from 'styled-components';
-import { MoonLoader } from 'react-spinners';
-import { useTranslation } from 'react-i18next';
-import { BtcOrdinal, Inscription } from '@secretkeylabs/xverse-core/types';
 import useInscriptionDetails from '@hooks/queries/ordinals/useInscriptionDetails';
 import OrdinalImage from '@screens/ordinals/ordinalImage';
+import { BtcOrdinal, Inscription } from '@secretkeylabs/xverse-core/types';
+import { useTranslation } from 'react-i18next';
+import { MoonLoader } from 'react-spinners';
+import styled from 'styled-components';
 
 const OrdinalCard = styled.div((props) => ({
   display: 'flex',
@@ -61,10 +61,11 @@ const LoaderContainer = styled.div({
 interface Props {
   ordinal: BtcOrdinal;
   isLoading: boolean;
+  disableTransfer: boolean;
   handleOrdinalTransfer: (ordinal: BtcOrdinal, ordinalData: Inscription) => Promise<void>;
 }
 
-function OrdinalRow({ ordinal, isLoading, handleOrdinalTransfer }: Props) {
+function OrdinalRow({ ordinal, isLoading, disableTransfer, handleOrdinalTransfer }: Props) {
   const { t } = useTranslation('translation');
   const ordinalData = useInscriptionDetails(ordinal.id);
 
@@ -85,7 +86,7 @@ function OrdinalRow({ ordinal, isLoading, handleOrdinalTransfer }: Props) {
         <ValueText>Ordinal</ValueText>
       </ColumnContainer>
       <ButtonContainer>
-        <TransferButton onClick={onClick}>
+        <TransferButton onClick={onClick} disabled={disableTransfer}>
           {isLoading ? (
             <LoaderContainer>
               <MoonLoader color="white" size={15} />


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

- [X] Bugfix

NOTE: We need to add the new version of core once the Xord Ordinal UTXO detection PR is merged before this is fully functional

# 📜 Background
When recovering ordinals, we would sometimes spend other ordinals for the transaction. This was because the confirmation screen would regenerate the signed txn hex if the fee was changed, but it wouldn't use the full list of ordinal UTXOs when doing so.

# 🔄 Changes
- Added the ordinal UTXO fetch in the confirm txn component so that we don't spend other ordinals
- Fixed an issue where clicking on `transfer` for an ordinal recovery, all the ordinals on the recover screen would show a loader

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.

Core pr: https://github.com/secretkeylabs/xverse-core/pull/203