### PR TITLE
chore: bump core version to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ledgerhq/hw-transport-webusb": "^6.27.13",
         "@react-spring/web": "^9.6.1",
-        "@secretkeylabs/xverse-core": "1.5.0",
+        "@secretkeylabs/xverse-core": "1.6.0",
         "@stacks/connect": "^6.10.2",
         "@stacks/encryption": "4.3.5",
         "@stacks/stacks-blockchain-api-types": "^6.1.1",
@@ -2198,9 +2198,9 @@
       }
     },
     "node_modules/@secretkeylabs/xverse-core": {
-      "version": "1.5.0",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.5.0/58581099268fa16d2dae4675eb405221c36e8666",
-      "integrity": "sha512-HCKndxD3IOgx5DMIocRu1KemQ8joquLS/CM8EKEKMu/g48xrkp3s9f7P46xMSpbsf6kPwP+YFi661XZ9GMFCRg==",
+      "version": "1.6.0",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.6.0/b0b99f470339d5b843022870aac3ea6dc9c270fd",
+      "integrity": "sha512-8IhkAEkfPSm3AAFkq6EnJ2H8plXBIm43MBETU9E6C9a3yoVe/Fv3iRnWEZqKcyd+EUnNxm9Mq1QHVln3W8ZKbA==",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
@@ -20361,9 +20361,9 @@
       }
     },
     "@secretkeylabs/xverse-core": {
-      "version": "1.5.0",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.5.0/58581099268fa16d2dae4675eb405221c36e8666",
-      "integrity": "sha512-HCKndxD3IOgx5DMIocRu1KemQ8joquLS/CM8EKEKMu/g48xrkp3s9f7P46xMSpbsf6kPwP+YFi661XZ9GMFCRg==",
+      "version": "1.6.0",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.6.0/b0b99f470339d5b843022870aac3ea6dc9c270fd",
+      "integrity": "sha512-8IhkAEkfPSm3AAFkq6EnJ2H8plXBIm43MBETU9E6C9a3yoVe/Fv3iRnWEZqKcyd+EUnNxm9Mq1QHVln3W8ZKbA==",
       "requires": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
         "@noble/secp256k1": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@ledgerhq/hw-transport-webusb": "^6.27.13",
     "@react-spring/web": "^9.6.1",
-    "@secretkeylabs/xverse-core": "1.5.0",
+    "@secretkeylabs/xverse-core": "1.6.0",
     "@stacks/connect": "^6.10.2",
     "@stacks/encryption": "4.3.5",
     "@stacks/stacks-blockchain-api-types": "^6.1.1",


### PR DESCRIPTION
# 🔘 PR Type
- [x] Bugfix
- [x] Enhancement

# 📜 Background
bump xverse-core to 1.6.0

# 🔄 Changes
## What's Changed
* Add `deviceAccountIndex` field for `Account` interface by @dhriaznov in https://github.com/secretkeylabs/xverse-core/pull/198
* feat: add logic for getting best UTXO combo for txn by @victorkirov in https://github.com/secretkeylabs/xverse-core/pull/195
* feat: implement required calls to inscribe service for BRC20 transfer by @victorkirov in https://github.com/secretkeylabs/xverse-core/pull/182
* Ordinal transaction functions by @abdulhaseeb4239 in https://github.com/secretkeylabs/xverse-core/pull/201
* Add utils for displaying Brc20 token transaction history by @Imamah-Zafar in https://github.com/secretkeylabs/xverse-core/pull/185


**Full Changelog**: https://github.com/secretkeylabs/xverse-core/compare/v1.5.1...v1.6.0
