### PR TITLE
chore: bump xverse-core to 1.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ledgerhq/hw-transport-webusb": "^6.27.13",
         "@react-spring/web": "^9.6.1",
-        "@secretkeylabs/xverse-core": "1.6.0",
+        "@secretkeylabs/xverse-core": "1.6.1",
         "@stacks/connect": "^6.10.2",
         "@stacks/encryption": "4.3.5",
         "@stacks/stacks-blockchain-api-types": "^6.1.1",
@@ -2198,9 +2198,9 @@
       }
     },
     "node_modules/@secretkeylabs/xverse-core": {
-      "version": "1.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.6.0/b0b99f470339d5b843022870aac3ea6dc9c270fd",
-      "integrity": "sha512-8IhkAEkfPSm3AAFkq6EnJ2H8plXBIm43MBETU9E6C9a3yoVe/Fv3iRnWEZqKcyd+EUnNxm9Mq1QHVln3W8ZKbA==",
+      "version": "1.6.1",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.6.1/52d91ebb1561e89ce3415f0bd40aa930f1d609be",
+      "integrity": "sha512-W1B//al40AtpECbqv3zXE4lsyXpT79mj2QiN5n3udslL51gQZ+oYX9rKjyumppGyxpB4y6PZ+QvkbEvz8zGAqg==",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
@@ -20361,9 +20361,9 @@
       }
     },
     "@secretkeylabs/xverse-core": {
-      "version": "1.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.6.0/b0b99f470339d5b843022870aac3ea6dc9c270fd",
-      "integrity": "sha512-8IhkAEkfPSm3AAFkq6EnJ2H8plXBIm43MBETU9E6C9a3yoVe/Fv3iRnWEZqKcyd+EUnNxm9Mq1QHVln3W8ZKbA==",
+      "version": "1.6.1",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.6.1/52d91ebb1561e89ce3415f0bd40aa930f1d609be",
+      "integrity": "sha512-W1B//al40AtpECbqv3zXE4lsyXpT79mj2QiN5n3udslL51gQZ+oYX9rKjyumppGyxpB4y6PZ+QvkbEvz8zGAqg==",
       "requires": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
         "@noble/secp256k1": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@ledgerhq/hw-transport-webusb": "^6.27.13",
     "@react-spring/web": "^9.6.1",
-    "@secretkeylabs/xverse-core": "1.6.0",
+    "@secretkeylabs/xverse-core": "1.6.1",
     "@stacks/connect": "^6.10.2",
     "@stacks/encryption": "4.3.5",
     "@stacks/stacks-blockchain-api-types": "^6.1.1",


### PR DESCRIPTION
# 🔘 PR Type

- [x] Bugfix
- [x] Enhancement


# 🔄 Changes
chore: use release published to trigger a release-package workflow by @teebszet in https://github.com/secretkeylabs/xverse-core/pull/208
feat: use xord for ordinal detection by @victorkirov in https://github.com/secretkeylabs/xverse-core/pull/203
fix internalPublicKey update with default by @m-aboelenein in https://github.com/secretkeylabs/xverse-core/pull/206