### PR TITLE
feat: change restore and backup wallet inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.15.0",
       "dependencies": {
         "@ledgerhq/hw-transport-webusb": "^6.27.13",
+        "@phosphor-icons/react": "^2.0.10",
         "@react-spring/web": "^9.6.1",
         "@secretkeylabs/xverse-core": "1.6.1",
         "@stacks/connect": "^6.10.2",
@@ -1999,6 +2000,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@phosphor-icons/react": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.0.10.tgz",
+      "integrity": "sha512-q5ITPNFhmEiYZLZOvEhjo2phlfxoOmit7vE1tBYMxcMqnZX2vdbMw3deDE7wCegpBKM/q/p39BJmhhoPcjZyCg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8",
+        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -20239,6 +20252,12 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@phosphor-icons/react": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.0.10.tgz",
+      "integrity": "sha512-q5ITPNFhmEiYZLZOvEhjo2phlfxoOmit7vE1tBYMxcMqnZX2vdbMw3deDE7wCegpBKM/q/p39BJmhhoPcjZyCg==",
+      "requires": {}
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.10",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "dependencies": {
     "@ledgerhq/hw-transport-webusb": "^6.27.13",
+    "@phosphor-icons/react": "^2.0.10",
     "@react-spring/web": "^9.6.1",
     "@secretkeylabs/xverse-core": "1.6.1",
     "@stacks/connect": "^6.10.2",

--- a/src/app/components/guards/auth.tsx
+++ b/src/app/components/guards/auth.tsx
@@ -1,20 +1,22 @@
 import useHasStateRehydrated from '@hooks/stores/useHasRehydrated';
 import useWalletSelector from '@hooks/useWalletSelector';
-import { ReactNode } from 'react';
 import { Navigate } from 'react-router-dom';
 
-interface AuthGuardProps {
-  children: ReactNode;
-}
-
-function AuthGuard({ children }: AuthGuardProps) {
+function AuthGuard({ children }: React.PropsWithChildren) {
   const { encryptedSeed, seedPhrase } = useWalletSelector();
   const hydrated = useHasStateRehydrated();
-  if (hydrated && encryptedSeed && !seedPhrase) return <Navigate to="/login" />;
 
-  if (hydrated && !encryptedSeed) return <Navigate to="/landing" />;
+  if (hydrated && encryptedSeed && !seedPhrase) {
+    return <Navigate to="/login" />;
+  }
 
-  return children;
+  if (hydrated && !encryptedSeed) {
+    return <Navigate to="/landing" />;
+  }
+
+  // fragment is required here
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return <>{children}</>;
 }
 
 export default AuthGuard;

--- a/src/app/components/guards/singleTab.tsx
+++ b/src/app/components/guards/singleTab.tsx
@@ -49,18 +49,20 @@ export const useSingleTabGuard = (guardName: GuardType, broadcastOnLoad = true):
   }, []);
 };
 
-type SingleTabProps = {
-  guardName: GuardType;
-  children?: React.ReactElement | React.ReactElement[];
-};
-
 /**
  * This guard is used to ensure that only one window with the guard name is open at a time.
  * It fires off an event only once on its first render and will close the window if it receives
  * the event.
  */
-export function SingleTabGuard({ guardName, children }: SingleTabProps): React.ReactNode {
+export function SingleTabGuard({
+  guardName,
+  children,
+}: React.PropsWithChildren<{
+  guardName: GuardType;
+}>) {
   useSingleTabGuard(guardName);
 
-  return children;
+  // fragment is required here
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return <>{children}</>;
 }

--- a/src/app/components/passwordInput/index.tsx
+++ b/src/app/components/passwordInput/index.tsx
@@ -119,6 +119,7 @@ const PasswordStrengthContainer = styled.div((props) => ({
 
 const StrengthBar = styled(animated.div)<StrengthBarProps>((props) => ({
   display: 'flex',
+  flex: '1 0',
   alignItems: 'center',
   backgroundColor: props.theme.colors.white[600],
   marginLeft: props.theme.spacing(6),

--- a/src/app/components/seedPhraseInput/index.tsx
+++ b/src/app/components/seedPhraseInput/index.tsx
@@ -1,78 +1,196 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
+import { Eye, EyeSlash } from '@phosphor-icons/react';
 
-const InputContainer = styled.div({
-  display: 'flex',
-  flexDirection: 'column',
-});
+const Label = styled.label`
+  ${(props) => props.theme.body_medium_m};
+  display: block;
+  margin-bottom: ${(props) => props.theme.spacing(4)}px;
+`;
 
-const SeedPhraseInputLabel = styled.p((props) => ({
-  ...props.theme.body_bold_m,
-  textAlign: 'left',
-  marginBottom: props.theme.spacing(8),
-}));
+const InputGroup = styled.div`
+  position: relative;
+`;
 
-interface ContainerProps {
-  error: boolean;
+const Input = styled.input`
+  ${(props) => props.theme.body_medium_m};
+  max-width: 144px;
+  min-height: ${(props) => props.theme.spacing(22)}px;
+  background-color: ${(props) => props.theme.colors.background.elevation0};
+  color: ${(props) => props.theme.colors.white['0']};
+  border: 1px solid ${(props) => props.theme.colors.background.elevation3};
+  border-radius: ${(props) => props.theme.radius(1)}px;
+  padding: ${(props) => props.theme.spacing(8)}px ${(props) => props.theme.spacing(6)}px;
+  padding-right: ${(props) => props.theme.spacing(26)}px;
+  caret-color: ${(props) => props.theme.colors.background.elevation6};
+  :focus-within {
+    border: 1px solid ${(props) => props.theme.colors.background.elevation6};
+  }
+`;
+
+const IconButton = styled.button`
+  position: absolute;
+  vertical-align: middle;
+  background-color: transparent;
+  color: ${(props) => props.theme.colors.white['0']};
+  border: none;
+  height: 100%;
+  right: 0;
+  top: 0;
+  margin-right: ${(props) => props.theme.spacing(8)}px;
+`;
+
+function SeedWordInput({
+  value,
+  index,
+  handleChangeInput,
+  disabled,
+}: {
+  value: string;
+  index: number;
+  handleChangeInput: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  disabled?: boolean;
+}) {
+  const [showValue, setShowValue] = useState(false);
+
+  const handleClickEye = () => setShowValue((prev) => !prev);
+  const handleFocusInput = () => setShowValue(true);
+  const handleBlurInput = () => setShowValue(false);
+  const handlePasteInput = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+  };
+
+  return (
+    <div>
+      <Label htmlFor={`input${index}`}>{`${index + 1}.`}</Label>
+      <InputGroup>
+        <Input
+          id={`input${index}`}
+          type={showValue ? 'input' : 'password'}
+          value={value}
+          spellCheck={false}
+          autoComplete="off"
+          autoCorrect="off"
+          onChange={handleChangeInput}
+          onPaste={handlePasteInput}
+          onFocus={handleFocusInput}
+          onBlur={handleBlurInput}
+          disabled={disabled}
+        />
+        <IconButton onClick={handleClickEye} tabIndex={-1}>
+          {showValue ? <Eye size={20} /> : <EyeSlash size={20} />}
+        </IconButton>
+      </InputGroup>
+    </div>
+  );
 }
 
-const SeedphraseInput = styled.textarea<ContainerProps>((props) => ({
-  ...props.theme.body_medium_m,
-  backgroundColor: props.theme.colors.background.elevation0,
-  color: props.theme.colors.white['0'],
-  width: '100%',
-  resize: 'none',
-  minHeight: 140,
-  padding: props.theme.spacing(8),
-  border: props.error
-    ? `1px solid ${props.theme.colors.feedback.error_700}`
-    : `1px solid ${props.theme.colors.background.elevation3}`,
-  outline: 'none',
-  borderRadius: props.theme.radius(1),
-  ':focus-within': {
-    border: `1px solid ${props.theme.colors.background.elevation6}`,
-  },
-}));
-const ErrorMessage = styled.h2((props) => ({
-  ...props.theme.body_medium_m,
-  textAlign: 'left',
-  color: props.theme.colors.feedback.error,
-  marginTop: props.theme.spacing(4),
-}));
+const InputContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: ${(props) => props.theme.spacing(40)}px;
+`;
 
-interface SeedPhraseInputProps {
-  seed: string;
+const InputGrid = styled.div<{ visible?: boolean }>`
+  display: grid;
+  grid-template-columns: repeat(4, auto);
+  row-gap: ${(props) => props.theme.spacing(8)}px;
+  column-gap: ${(props) => props.theme.spacing(4)}px;
+  max-height: ${(props) => (props.visible ? '400px' : '0')};
+  overflow: hidden;
+  transition: max-height 0.1s ease-in-out;
+  :not(:first-child) {
+    margin-top: ${(props) => (props.visible ? '16px' : '0')};
+  }
+`;
+
+const ErrorMessage = styled.p<{ visible: boolean }>`
+  ${(props) => props.theme.body_medium_m};
+  visibility: ${(props) => (props.visible ? 'visible' : 'hidden')};
+  text-align: left;
+  color: ${(props) => props.theme.colors.feedback.error};
+  margin-top: ${(props) => props.theme.spacing(8)}px;
+  margin-bottom: ${(props) => props.theme.spacing(8)}px;
+`;
+
+const TransparentButton = styled.button`
+  ${(props) => props.theme.body_m};
+  background-color: transparent;
+  border: none;
+  color: ${(props) => props.theme.colors.white['200']};
+  text-decoration: underline;
+`;
+
+const seedInit: string[] = [];
+for (let i = 0; i < 24; i += 1) {
+  seedInit.push('');
+}
+
+export default function SeedPhraseInput({
+  onSeedChange,
+  seedError,
+  setSeedError,
+}: {
   onSeedChange: (seed: string) => void;
   seedError: string;
   setSeedError: (err: string) => void;
-}
-
-export default function SeedPhraseInput(props: SeedPhraseInputProps): JSX.Element {
+}) {
   const { t } = useTranslation('translation', { keyPrefix: 'RESTORE_WALLET_SCREEN' });
-  const { onSeedChange, seed, seedError, setSeedError } = props;
+  const [seedInput, setSeedInput] = useState([...seedInit]);
+  const [show24Words, setShow24Words] = useState(false);
 
-  const handleSeedChange = (event: React.FormEvent<HTMLTextAreaElement>) => {
+  const handleChangeInput = (index: number) => (event: React.ChangeEvent<HTMLInputElement>) => {
     if (seedError) {
       setSeedError('');
     }
-    onSeedChange(event.currentTarget.value);
+
+    setSeedInput((prevSeed) => {
+      prevSeed[index] = event.target.value;
+      return [...prevSeed];
+    });
+  };
+
+  useEffect(() => {
+    const seedPhrase = seedInput
+      .slice(0, !show24Words ? 12 : 24)
+      .filter(Boolean)
+      .join(' ');
+    onSeedChange(seedPhrase);
+  }, [seedInput, onSeedChange, show24Words]);
+
+  const handleClickShow24Words = () => {
+    setShow24Words((prev) => !prev);
+    setSeedInput((prev) => prev.slice(0, 12).concat(seedInit.slice(0, 12)));
   };
 
   return (
     <InputContainer>
-      <SeedPhraseInputLabel>{t('SEED_INPUT_LABEL')}</SeedPhraseInputLabel>
-      <SeedphraseInput
-        error={seedError !== ''}
-        value={seed}
-        name="secretKey"
-        placeholder={t('SEED_INPUT_PLACEHOLDER')}
-        onChange={handleSeedChange}
-        spellCheck={false}
-        autoComplete="off"
-        autoCorrect="off"
-      />
-      {seedError ? <ErrorMessage>{seedError}</ErrorMessage> : null}
+      <InputGrid visible>
+        {seedInput.slice(0, 12).map((value, index) => (
+          <SeedWordInput
+            key={index} // eslint-disable-line react/no-array-index-key
+            value={value}
+            index={index}
+            handleChangeInput={handleChangeInput(index)}
+          />
+        ))}
+      </InputGrid>
+      <InputGrid visible={show24Words}>
+        {seedInput.slice(12, 24).map((value, index) => (
+          <SeedWordInput
+            key={index + 12} // eslint-disable-line react/no-array-index-key
+            value={value}
+            index={index + 12}
+            handleChangeInput={handleChangeInput(index + 12)}
+            disabled={!show24Words}
+          />
+        ))}
+      </InputGrid>
+      <ErrorMessage visible={!!seedError}>{seedError}</ErrorMessage>
+      <TransparentButton onClick={handleClickShow24Words}>
+        {t('HAVE_A_24_WORDS_SEEDPHRASE?', { number: show24Words ? '12' : '24' })}
+      </TransparentButton>
     </InputContainer>
   );
 }

--- a/src/app/components/seedPhraseInput/index.tsx
+++ b/src/app/components/seedPhraseInput/index.tsx
@@ -29,7 +29,7 @@ const Input = styled.input`
   }
 `;
 
-const IconButton = styled.button`
+const Icon = styled.i`
   position: absolute;
   vertical-align: middle;
   background-color: transparent;
@@ -39,6 +39,10 @@ const IconButton = styled.button`
   right: 0;
   top: 0;
   margin-right: ${(props) => props.theme.spacing(8)}px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  pointer-events: none;
 `;
 
 function SeedWordInput({
@@ -54,7 +58,6 @@ function SeedWordInput({
 }) {
   const [showValue, setShowValue] = useState(false);
 
-  const handleClickEye = () => setShowValue((prev) => !prev);
   const handleFocusInput = () => setShowValue(true);
   const handleBlurInput = () => setShowValue(false);
   const handlePasteInput = (e: React.ClipboardEvent<HTMLInputElement>) => {
@@ -65,6 +68,7 @@ function SeedWordInput({
     <div>
       <Label htmlFor={`input${index}`}>{`${index + 1}.`}</Label>
       <InputGroup>
+        <Icon tabIndex={-1}>{showValue ? <Eye size={20} /> : <EyeSlash size={20} />}</Icon>
         <Input
           id={`input${index}`}
           type={showValue ? 'input' : 'password'}
@@ -78,9 +82,6 @@ function SeedWordInput({
           onBlur={handleBlurInput}
           disabled={disabled}
         />
-        <IconButton onClick={handleClickEye} tabIndex={-1}>
-          {showValue ? <Eye size={20} /> : <EyeSlash size={20} />}
-        </IconButton>
       </InputGroup>
     </div>
   );
@@ -89,7 +90,7 @@ function SeedWordInput({
 const InputContainer = styled.div`
   display: flex;
   flex-direction: column;
-  margin-bottom: ${(props) => props.theme.spacing(40)}px;
+  margin-bottom: ${(props) => props.theme.spacing(12)}px;
 `;
 
 const InputGrid = styled.div<{ visible?: boolean }>`
@@ -106,12 +107,12 @@ const InputGrid = styled.div<{ visible?: boolean }>`
 `;
 
 const ErrorMessage = styled.p<{ visible: boolean }>`
-  ${(props) => props.theme.body_medium_m};
+  ${(props) => props.theme.body_s};
   visibility: ${(props) => (props.visible ? 'visible' : 'hidden')};
-  text-align: left;
+  text-align: center;
   color: ${(props) => props.theme.colors.feedback.error};
-  margin-top: ${(props) => props.theme.spacing(8)}px;
-  margin-bottom: ${(props) => props.theme.spacing(8)}px;
+  margin-top: ${(props) => props.theme.spacing(12)}px;
+  margin-bottom: ${(props) => props.theme.spacing(15)}px;
 `;
 
 const TransparentButton = styled.button`

--- a/src/app/components/seedPhraseView/index.tsx
+++ b/src/app/components/seedPhraseView/index.tsx
@@ -26,6 +26,7 @@ const SeedContainer = styled.div<SeedContainerProps>((props) => ({
   paddingBottom: props.theme.spacing(17),
   paddingLeft: props.theme.spacing(5),
   filter: `blur(${props.isVisible ? 0 : '3px'})`,
+  userSelect: 'none',
 }));
 
 const OuterSeedContainer = styled.div((props) => ({

--- a/src/app/routes/index.tsx
+++ b/src/app/routes/index.tsx
@@ -36,10 +36,6 @@ import RestoreOrdinals from '@screens/restoreFunds/restoreOrdinals';
 import ImportLedger from '@screens/ledger/importLedgerAccount';
 import VerifyLedger from '@screens/ledger/verifyLedgerAccountAddress';
 import ConfirmLedgerTransaction from '@screens/ledger/confirmLedgerTransaction';
-import LedgerSendStxScreen from '@screens/ledger/ledgerSendStx';
-import ReviewLedgerStxTransaction from '@screens/ledger/reviewLedgerStxTransaction';
-import LedgerSendFtScreen from '@screens/ledger/ledgerSendFt';
-import ReviewLedgerFtTransaction from '@screens/ledger/reviewLedgerFtTransaction';
 import BtcSendScreen from '@screens/btcSendScreen';
 import RestoreWallet from '@screens/restoreWallet';
 import SendBrc20Screen from '@screens/sendBrc20';
@@ -251,14 +247,6 @@ const router = createHashRouter([
         element: <Login />,
       },
       {
-        path: 'restoreWallet',
-        element: (
-          <OnboardingGuard>
-            <RestoreWallet />
-          </OnboardingGuard>
-        ),
-      },
-      {
         path: 'forgotPassword',
         element: <ForgotPassword />,
       },
@@ -411,6 +399,14 @@ const router = createHashRouter([
           <AuthGuard>
             <SendOrdinal />
           </AuthGuard>
+        ),
+      },
+      {
+        path: 'restoreWallet',
+        element: (
+          <OnboardingGuard>
+            <RestoreWallet />
+          </OnboardingGuard>
         ),
       },
     ],

--- a/src/app/screens/backupWalletSteps/index.tsx
+++ b/src/app/screens/backupWalletSteps/index.tsx
@@ -112,7 +112,7 @@ export default function BackupWalletSteps(): JSX.Element {
     <PasswordContainer>
       <PasswordInput
         title={t('CONFIRM_PASSWORD_TITLE')}
-        inputLabel={t('TEXT_INPUT_CONFIRM_PASSWORD_LABEL')}
+        inputLabel={t('TEXT_INPUT_NEW_PASSWORD_LABEL')}
         enteredPassword={confirmPassword}
         setEnteredPassword={setConfirmPassword}
         handleContinue={handleConfirmPasswordContinue}

--- a/src/app/screens/backupWalletSteps/verifySeed.tsx
+++ b/src/app/screens/backupWalletSteps/verifySeed.tsx
@@ -1,8 +1,8 @@
-import ActionButton from '@components/button';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { generateMnemonic } from 'bip39';
+import ActionButton from '@components/button';
 
 const Container = styled.div((props) => ({
   display: 'flex',
@@ -90,9 +90,9 @@ export default function VerifySeed({
   onBack: () => void;
   onVerifySuccess: () => void;
   seedPhrase: string;
-}): JSX.Element {
-  const [err, setErr] = useState('');
+}) {
   const { t } = useTranslation('translation', { keyPrefix: 'BACKUP_WALLET_SCREEN' });
+  const [err, setErr] = useState('');
   const [correctCounter, setCorrectCounter] = useState(0);
   const [quiz, setQuiz] = useState<{ words: string[]; answer: string; nth: string }>({
     words: [],
@@ -101,29 +101,27 @@ export default function VerifySeed({
   });
 
   const generateWords = useCallback(() => {
-    const words = generateMnemonic().split(' ');
-    const randomWordsIndex = Math.floor(Math.random() * words.length);
-    const seedPhraseIndex = Math.floor(Math.random() * seedPhrase.split(' ').length);
-    const answer = seedPhrase.split(' ')[seedPhraseIndex];
-    words[randomWordsIndex] = answer;
+    const randomWords = generateMnemonic().split(' ');
+    const seedWords = seedPhrase.split(' ');
+    const randomWordsIndex = Math.floor(Math.random() * randomWords.length);
+    const seedPhraseIndex = Math.floor(Math.random() * seedWords.length);
+    const answer = seedWords[seedPhraseIndex];
+    randomWords[randomWordsIndex] = answer;
     const nth = getOrdinal(seedPhraseIndex + 1);
-    setQuiz({ words, answer, nth });
+    setQuiz({ words: randomWords, answer, nth });
   }, [seedPhrase]);
 
   useEffect(() => {
-    generateWords();
-  }, [generateWords, correctCounter]);
-
-  useEffect(() => {
     if (correctCounter >= 3) {
-      onVerifySuccess();
+      return onVerifySuccess();
     }
-  }, [correctCounter, onVerifySuccess]);
+    generateWords();
+  }, [correctCounter, onVerifySuccess, generateWords]);
 
   const handleClickWord = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (e.currentTarget.value === quiz.answer) {
-      setCorrectCounter((prev) => prev + 1);
-      return setErr('');
+      setErr('');
+      return setCorrectCounter((prev) => prev + 1);
     }
     setErr(t('SEED_PHRASE_INCORRECT'));
   };

--- a/src/app/screens/backupWalletSteps/verifySeed.tsx
+++ b/src/app/screens/backupWalletSteps/verifySeed.tsx
@@ -100,12 +100,20 @@ export default function VerifySeed({
   });
 
   const generateWords = useCallback(() => {
-    const randomWords = generateMnemonic().split(' ');
     const seedWords = seedPhrase.split(' ');
-    const randomWordsIndex = Math.floor(Math.random() * randomWords.length);
     const seedPhraseIndex = Math.floor(Math.random() * seedWords.length);
     const answer = seedWords[seedPhraseIndex];
-    randomWords[randomWordsIndex] = answer;
+
+    const randomWords = generateMnemonic().split(' ');
+
+    // check randomWords doesn't contain our answer already.
+    // only if it doesn't, do we need to insert the answer at a random index.
+    const foundAnswerIndex = randomWords.findIndex((word) => word === answer);
+    if (foundAnswerIndex === -1) {
+      const randomWordsIndex = Math.floor(Math.random() * randomWords.length);
+      randomWords[randomWordsIndex] = answer;
+    }
+
     const nth = getOrdinal(seedPhraseIndex + 1);
     setQuiz({ words: randomWords, answer, nth });
   }, [seedPhrase]);

--- a/src/app/screens/backupWalletSteps/verifySeed.tsx
+++ b/src/app/screens/backupWalletSteps/verifySeed.tsx
@@ -48,7 +48,6 @@ const WordButton = styled.button`
   align-items: center;
   padding: ${(props) => props.theme.spacing(6)}px;
   border-radius: ${(props) => props.theme.radius(1)}px;
-  text-transform: capitalize;
   transition: all 0.1s ease;
   :hover:enabled {
     opacity: 0.8;

--- a/src/app/screens/backupWalletSteps/verifySeed.tsx
+++ b/src/app/screens/backupWalletSteps/verifySeed.tsx
@@ -123,9 +123,9 @@ export default function VerifySeed({
   const handleClickWord = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (e.currentTarget.value === quiz.answer) {
       setCorrectCounter((prev) => prev + 1);
-      return setErr(t('SEED_PHRASE_INCORRECT'));
+      return setErr('');
     }
-    setErr('');
+    setErr(t('SEED_PHRASE_INCORRECT'));
   };
 
   return (

--- a/src/app/screens/backupWalletSteps/verifySeed.tsx
+++ b/src/app/screens/backupWalletSteps/verifySeed.tsx
@@ -1,20 +1,14 @@
 import ActionButton from '@components/button';
-import SeedPhraseInput from '@components/seedPhraseInput';
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
+import { generateMnemonic } from 'bip39';
 
 const Container = styled.div((props) => ({
   display: 'flex',
   paddingTop: props.theme.spacing(21),
   flexDirection: 'column',
   flex: 1,
-}));
-
-const Heading = styled.p((props) => ({
-  ...props.theme.body_l,
-  color: props.theme.colors.white[200],
-  marginBottom: props.theme.spacing(15),
 }));
 
 const ButtonsContainer = styled.div((props) => ({
@@ -32,54 +26,127 @@ const TransparentButtonContainer = styled.div((props) => ({
   width: '100%',
 }));
 
-const ButtonContainer = styled.div((props) => ({
-  marginLeft: props.theme.spacing(2),
-  width: '100%',
+const Heading = styled.h3((props) => ({
+  ...props.theme.body_l,
+  color: props.theme.colors.white[200],
+  marginBottom: props.theme.spacing(16),
 }));
 
-interface VerifySeedProps {
-  onVerifySuccess: () => void;
-  onBack: () => void;
-  seedPhrase: string;
-}
+const WordGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: ${(props) => props.theme.spacing(5)}px;
+  margin-bottom: ${(props) => props.theme.spacing(12)}px;
+`;
 
-export default function VerifySeed(props: VerifySeedProps): JSX.Element {
-  const [seedInput, setSeedInput] = useState<string>('');
+const WordButton = styled.button`
+  ${(props) => props.theme.body_medium_m};
+  color: ${(props) => props.theme.colors.white['0']};
+  background-color: ${(props) => props.theme.colors.background.elevation3};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: ${(props) => props.theme.spacing(6)}px;
+  border-radius: ${(props) => props.theme.radius(1)}px;
+  text-transform: capitalize;
+  transition: all 0.1s ease;
+  :hover:enabled {
+    opacity: 0.8;
+  }
+  :active:enabled {
+    opacity: 0.6;
+  }
+`;
+
+const NthSpan = styled.span`
+  ${(props) => props.theme.body_bold_l};
+  color: ${(props) => props.theme.colors.white['0']};
+`;
+
+const ErrorMessage = styled.p<{ visible: boolean }>`
+  ${(props) => props.theme.body_s};
+  color: ${(props) => props.theme.colors.feedback.error};
+  visibility: ${(props) => (props.visible ? 'initial' : 'hidden')};
+`;
+
+const getOrdinal = (num: number): string => {
+  switch (num) {
+    case 1:
+      return '1st';
+    case 2:
+      return '2nd';
+    case 3:
+      return '3rd';
+    default:
+      return `${num}th`;
+  }
+};
+
+export default function VerifySeed({
+  onBack,
+  onVerifySuccess,
+  seedPhrase,
+}: {
+  onBack: () => void;
+  onVerifySuccess: () => void;
+  seedPhrase: string;
+}): JSX.Element {
   const [err, setErr] = useState('');
   const { t } = useTranslation('translation', { keyPrefix: 'BACKUP_WALLET_SCREEN' });
-  const { onBack, onVerifySuccess, seedPhrase } = props;
+  const [correctCounter, setCorrectCounter] = useState(0);
+  const [quiz, setQuiz] = useState<{ words: string[]; answer: string; nth: string }>({
+    words: [],
+    answer: '',
+    nth: '',
+  });
 
-  const cleanMnemonic = (rawSeed: string): string =>
-    rawSeed.replace(/\s\s+/g, ' ').replace(/\n/g, ' ').trim();
+  const generateWords = useCallback(() => {
+    const words = generateMnemonic().split(' ');
+    const randomWordsIndex = Math.floor(Math.random() * words.length);
+    const seedPhraseIndex = Math.floor(Math.random() * seedPhrase.split(' ').length);
+    const answer = seedPhrase.split(' ')[seedPhraseIndex];
+    words[randomWordsIndex] = answer;
+    const nth = getOrdinal(seedPhraseIndex + 1);
+    setQuiz({ words, answer, nth });
+  }, [seedPhrase]);
 
-  const handleVerify = () => {
-    if (seedPhrase === cleanMnemonic(seedInput)) {
+  useEffect(() => {
+    generateWords();
+  }, [generateWords, correctCounter]);
+
+  useEffect(() => {
+    if (correctCounter >= 3) {
       onVerifySuccess();
-    } else {
-      setErr('Seedphrase does not match');
     }
+  }, [correctCounter, onVerifySuccess]);
+
+  const handleClickWord = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (e.currentTarget.value === quiz.answer) {
+      setCorrectCounter((prev) => prev + 1);
+      return setErr(t('SEED_PHRASE_INCORRECT'));
+    }
+    setErr('');
   };
 
   return (
     <Container>
-      <Heading>{t('SEED_PHRASE_VERIFY_HEADING')}</Heading>
-      <SeedPhraseInput
-        seed={seedInput}
-        onSeedChange={setSeedInput}
-        seedError={err}
-        setSeedError={setErr}
-      />
+      <Heading>
+        {t('SELECT_THE')}
+        <NthSpan>{quiz.nth}</NthSpan>
+        {t('WORD_OF_YOUR_SEEDPHRASE')}
+      </Heading>
+      <WordGrid>
+        {quiz.words.map((word) => (
+          <WordButton key={word} onClick={handleClickWord} value={word}>
+            {word}
+          </WordButton>
+        ))}
+      </WordGrid>
+      <ErrorMessage visible={!!err}>{err}</ErrorMessage>
       <ButtonsContainer>
         <TransparentButtonContainer>
           <ActionButton onPress={onBack} transparent text={t('SEED_PHRASE_BACK_BUTTON')} />
         </TransparentButtonContainer>
-        <ButtonContainer>
-          <ActionButton
-            text={t('SEED_PHRASE_VERIFY_BUTTON')}
-            onPress={handleVerify}
-            disabled={seedInput === ''}
-          />
-        </ButtonContainer>
       </ButtonsContainer>
     </Container>
   );

--- a/src/app/screens/backupWalletSteps/verifySeed.tsx
+++ b/src/app/screens/backupWalletSteps/verifySeed.tsx
@@ -135,6 +135,7 @@ export default function VerifySeed({
 
   return (
     <Container>
+      <Heading>{t('CONFIRM_YOUR_SEEDPHRASE')}</Heading>
       <Heading>
         {t('SELECT_THE')}
         <NthSpan>{quiz.nth}</NthSpan>

--- a/src/app/screens/restoreWallet/enterSeedphrase.tsx
+++ b/src/app/screens/restoreWallet/enterSeedphrase.tsx
@@ -11,10 +11,11 @@ const Container = styled.div({
 });
 
 const Title = styled.h1((props) => ({
-  ...props.theme.body_l,
+  ...props.theme.body_m,
   color: props.theme.colors.white[200],
   marginTop: props.theme.spacing(21),
   marginBottom: props.theme.spacing(16),
+  textAlign: 'center',
 }));
 
 const ButtonContainer = styled.div((props) => ({
@@ -39,12 +40,7 @@ function EnterSeedPhrase(props: Props): JSX.Element {
   return (
     <Container>
       <Title>{t('ENTER_SEED_HEADER')}</Title>
-      <SeedPhraseInput
-        seed={seed}
-        onSeedChange={setSeed}
-        seedError={seedError}
-        setSeedError={setSeedError}
-      />
+      <SeedPhraseInput onSeedChange={setSeed} seedError={seedError} setSeedError={setSeedError} />
       <ButtonContainer>
         <ActionButton onPress={onContinue} disabled={seed === ''} text={t('CONTINUE_BUTTON')} />
       </ButtonContainer>

--- a/src/app/screens/restoreWallet/index.tsx
+++ b/src/app/screens/restoreWallet/index.tsx
@@ -120,7 +120,7 @@ function RestoreWallet(): JSX.Element {
     <PasswordContainer>
       <PasswordInput
         title={t('CREATE_PASSWORD_SCREEN.CONFIRM_PASSWORD_TITLE')}
-        inputLabel={t('CREATE_PASSWORD_SCREEN.TEXT_INPUT_CONFIRM_PASSWORD_LABEL')}
+        inputLabel={t('CREATE_PASSWORD_SCREEN.TEXT_INPUT_NEW_PASSWORD_LABEL')}
         enteredPassword={confirmPassword}
         setEnteredPassword={setConfirmPassword}
         handleContinue={handleConfirmPassword}

--- a/src/app/screens/restoreWallet/index.tsx
+++ b/src/app/screens/restoreWallet/index.tsx
@@ -9,20 +9,27 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import EnterSeedPhrase from './enterSeedphrase';
 
+const Body = styled.div(() => ({
+  display: 'flex',
+  height: '100%',
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
+
 const Container = styled.div((props) => ({
   display: 'flex',
   flexDirection: 'column',
-  marginLeft: 'auto',
-  marginRight: 'auto',
-  height: 600,
-  width: 360,
+  height: 'auto',
   backgroundColor: props.theme.colors.background.elevation0,
-  padding: `${props.theme.spacing(12)}px ${props.theme.spacing(8)}px 0 ${props.theme.spacing(8)}px`,
+  padding: `${props.theme.spacing(12)}px`,
+  border: `1px solid ${props.theme.colors.background.elevation2}`,
+  borderRadius: props.theme.radius(2),
 }));
 
 const PasswordContainer = styled.div((props) => ({
   display: 'flex',
   height: '100%',
+  width: '312px',
   marginBottom: props.theme.spacing(32),
   marginTop: props.theme.spacing(32),
 }));
@@ -30,13 +37,13 @@ const PasswordContainer = styled.div((props) => ({
 function RestoreWallet(): JSX.Element {
   const { t } = useTranslation('translation');
   const { restoreWallet } = useWalletReducer();
-  const [isRestoring, setIsRestoring] = useState<boolean>(false);
-  const [currentStepIndex, setCurrentStepIndex] = useState<number>(0);
-  const [password, setPassword] = useState<string>('');
-  const [confirmPassword, setConfirmPassword] = useState<string>('');
-  const [seedPhrase, setSeedPhrase] = useState<string>('');
-  const [seedError, setSeedError] = useState<string>('');
-  const [error, setError] = useState<string>('');
+  const [isRestoring, setIsRestoring] = useState(false);
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [seedPhrase, setSeedPhrase] = useState('');
+  const [seedError, setSeedError] = useState('');
+  const [error, setError] = useState('');
   const navigate = useNavigate();
   const { disableWalletExistsGuard } = useWalletExistsContext();
 
@@ -124,10 +131,12 @@ function RestoreWallet(): JSX.Element {
     </PasswordContainer>,
   ];
   return (
-    <Container>
-      <Steps data={restoreSteps} activeIndex={currentStepIndex} />
-      {restoreSteps[currentStepIndex]}
-    </Container>
+    <Body>
+      <Container>
+        <Steps data={restoreSteps} activeIndex={currentStepIndex} />
+        {restoreSteps[currentStepIndex]}
+      </Container>
+    </Body>
   );
 }
 

--- a/src/app/screens/settings/changePassword/index.tsx
+++ b/src/app/screens/settings/changePassword/index.tsx
@@ -127,8 +127,8 @@ function ChangePasswordScreen() {
         )}
         {currentStepIndex === 1 && (
           <PasswordInput
-            title={t('CREATE_PASSWORD_SCREEN.CREATE_PASSWORD_TITLE')}
-            inputLabel={t('CREATE_PASSWORD_SCREEN.TEXT_INPUT_NEW_PASSWORD_LABEL')}
+            title={t('SETTING_SCREEN.ENTER_YOUR_NEW_PASSWORD')}
+            inputLabel={t('SETTING_SCREEN.TEXT_INPUT_NEW_PASSWORD_LABEL')}
             enteredPassword={password}
             setEnteredPassword={setPassword}
             handleContinue={handleEnterNewPasswordNextClick}
@@ -140,8 +140,8 @@ function ChangePasswordScreen() {
         )}
         {currentStepIndex === 2 && (
           <PasswordInput
-            title={t('CREATE_PASSWORD_SCREEN.CONFIRM_PASSWORD_TITLE')}
-            inputLabel={t('CREATE_PASSWORD_SCREEN.TEXT_INPUT_CONFIRM_PASSWORD_LABEL')}
+            title={t('SETTING_SCREEN.CONFIRM_YOUR_NEW_PASSWORD')}
+            inputLabel={t('SETTING_SCREEN.TEXT_INPUT_NEW_PASSWORD_LABEL')}
             enteredPassword={confirmPassword}
             setEnteredPassword={setConfirmPassword}
             handleContinue={handleConfirmNewPasswordNextClick}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -353,7 +353,10 @@
     "SEED_PHRASE_VIEW_CONTINUE": "Continue",
     "SEED_PHRASE_VERIFY_HEADING": "Write your seedphrase to confirm you saved it properly.",
     "SEED_PHRASE_VERIFY_BUTTON": "Verify",
-    "SEED_PHRASE_BACK_BUTTON": "Back"
+    "SEED_PHRASE_BACK_BUTTON": "Back to seedphrase",
+    "SEED_PHRASE_INCORRECT": "This word is not correct.",
+    "SELECT_THE": "Select the ",
+    "WORD_OF_YOUR_SEEDPHRASE": " word of your seedphrase."
   },
   "CREATE_PASSWORD_SCREEN": {
     "CREATE_PASSWORD_TITLE": "Enter your new password",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -438,11 +438,10 @@
     "BACKUP_CHECKBOX_LABEL": "I backed up my seedphrase"
   },
   "RESTORE_WALLET_SCREEN": {
-    "ENTER_SEED_HEADER": "Enter your 12 or 24 word seedphrase to restore your wallet",
-    "SEED_INPUT_PLACEHOLDER": "Enter your seedphrase",
-    "SEED_INPUT_LABEL": "Selected Words",
+    "ENTER_SEED_HEADER": "Enter your seedphrase to restore your wallet.",
     "SEED_INPUT_ERROR": "Invalid seed phrase, please try again",
-    "CONTINUE_BUTTON": "Continue"
+    "CONTINUE_BUTTON": "Continue",
+    "HAVE_A_24_WORDS_SEEDPHRASE?": "Have a {{number}} words seedphrase?"
   },
   "STACKING_SCREEN": {
     "STACK_AND_EARN": "Stack STX, earn BTC",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -360,10 +360,10 @@
     "CONFIRM_YOUR_SEEDPHRASE": "Confirm you've recorded your seed phrase correctly."
   },
   "CREATE_PASSWORD_SCREEN": {
-    "CREATE_PASSWORD_TITLE": "Enter your new password",
-    "CONFIRM_PASSWORD_TITLE": "Confirm your new password",
+    "CREATE_PASSWORD_TITLE": "Enter a password to protect your wallet",
+    "CONFIRM_PASSWORD_TITLE": "Confirm your password",
     "ENTER_PASSWORD": "Enter your current password",
-    "TEXT_INPUT_NEW_PASSWORD_LABEL": "New Password",
+    "TEXT_INPUT_NEW_PASSWORD_LABEL": "Password",
     "TEXT_INPUT_ENTER_PASSWORD_LABEL": "Enter your current password",
     "TEXT_INPUT_CONFIRM_PASSWORD_LABEL": "Confirm Password",
     "CONTINUE_BUTTON": "Continue",
@@ -599,7 +599,10 @@
     "ACTIVATE_ORDINAL_NFTS": "Display ordinals",
     "RECOVER_ASSETS": "Recover assets",
     "LOCK_COUNTDOWN": "Auto-lock Timer",
-    "LOCK_COUNTDOWN_TITLE": "Select the time duration before the wallet locks automatically."
+    "LOCK_COUNTDOWN_TITLE": "Select the time duration before the wallet locks automatically.",
+    "ENTER_YOUR_NEW_PASSWORD": "Enter your new password",
+    "CONFIRM_YOUR_NEW_PASSWORD": "Confirm your new password",
+    "TEXT_INPUT_NEW_PASSWORD_LABEL": "New Password"
   },
   "OPTIONS_DIALOG": {
     "SWITCH_ACCOUNT": "Switch Account",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -356,7 +356,8 @@
     "SEED_PHRASE_BACK_BUTTON": "Back to seedphrase",
     "SEED_PHRASE_INCORRECT": "This word is not correct.",
     "SELECT_THE": "Select the ",
-    "WORD_OF_YOUR_SEEDPHRASE": " word of your seedphrase."
+    "WORD_OF_YOUR_SEEDPHRASE": " word of your seedphrase.",
+    "CONFIRM_YOUR_SEEDPHRASE": "Confirm you've recorded your seed phrase correctly."
   },
   "CREATE_PASSWORD_SCREEN": {
     "CREATE_PASSWORD_TITLE": "Enter your new password",

--- a/src/theme/global.ts
+++ b/src/theme/global.ts
@@ -85,8 +85,8 @@ const GlobalStyle = createGlobalStyle`
     text-decoration: none;
   }
   * a:hover {
-    text-decoration:none; 
-    cursor:pointer;  
+    text-decoration:none;
+    cursor:pointer;
 }
 *,
 *::after,

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -15,6 +15,7 @@ const Theme = {
       900: 'rgba(255, 255, 255, 0.1)',
     },
     background: {
+      elevation_n1: '#0C0C0C',
       elevation0: '#12151E',
       elevation1: '#1D2032', // deprecated?
       elevation_1: '#070A13',


### PR DESCRIPTION
# 🔘 PR Type
- [x] Enhancement

# 📜 Background
Issue Link: https://linear.app/xverseapp/issue/ENG-2604/patch-demonic-vulnerability
Context Link (if applicable):

# 🔄 Changes
- restore wallet screen inputs are 12 or 24 input boxes
- create wallet flow will verify based on guessing 3 correct words
- disable user select and copy on any component displaying the whole seed phrase
- add phosphor icon set according to zeroheight https://zeroheight.com/0683c9fa7/p/66541d-icons/b/095f0e
- fix lint errors on routes/index.ts

# 🖼 Screenshot / 📹 Video

https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/7ed04fab-cedb-4741-9df0-3bd8cc8e360f

https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/d83fd456-9360-4f9c-ac5b-24a20ca65445

https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/d2b4a977-284f-4e42-b98d-cecc700130db

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
