### PR TITLE
Filter out dead pending transactions

### DIFF
--- a/src/app/screens/swap/useAlexSponsoredTransaction.ts
+++ b/src/app/screens/swap/useAlexSponsoredTransaction.ts
@@ -1,8 +1,14 @@
 import { useEffect, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { StacksTransaction } from '@secretkeylabs/xverse-core';
+import {
+  getConfirmedTransactions,
+  StacksTransaction,
+  StxTransactionListData,
+} from '@secretkeylabs/xverse-core';
 import { AlexSDK } from 'alex-sdk';
 import useStxPendingTxData from '@hooks/queries/useStxPendingTxData';
+import useWalletSelector from '@hooks/useWalletSelector';
+import useNetworkSelector from '@hooks/useNetwork';
 
 const useAlexSponsorSwapEnabledQuery = (alexSDK: AlexSDK) =>
   useQuery({
@@ -13,7 +19,11 @@ const useAlexSponsorSwapEnabledQuery = (alexSDK: AlexSDK) =>
 export const useAlexSponsoredTransaction = (userOverrideSponsorValue: boolean) => {
   const alexSDK = useRef(new AlexSDK()).current;
   const [isServiceRunning, setIsServiceRunning] = useState(false);
+  const [hasPendingTransactions, setHasPendingTransactions] = useState(false);
   const { error, data: isEnabled, isLoading } = useAlexSponsorSwapEnabledQuery(alexSDK);
+  const { stxAddress } = useWalletSelector();
+  const selectedNetwork = useNetworkSelector();
+  const { data: stxPendingTxData } = useStxPendingTxData();
 
   useEffect(() => {
     if (!isLoading && !error) {
@@ -24,17 +34,35 @@ export const useAlexSponsoredTransaction = (userOverrideSponsorValue: boolean) =
   const sponsorTransaction = async (signed: StacksTransaction) =>
     alexSDK.broadcastSponsoredTx(signed.serialize().toString('hex'));
 
-  const { data: stxPendingTxData } = useStxPendingTxData();
-  const currentNonce =
-    (stxPendingTxData?.pendingTransactions ?? []).reduce(
-      (maxNonce, transaction) => Math.max(maxNonce, transaction?.nonce ?? 0),
-      0,
-    ) + 1;
+  const getAccountCurrentNonce = async () => {
+    let nonce = 0;
+    const confirmedTransactions: StxTransactionListData = await getConfirmedTransactions({
+      stxAddress,
+      network: selectedNetwork,
+    });
 
-  const filteredStxPendingTxData = stxPendingTxData?.pendingTransactions.filter(
-    (transaction) => currentNonce - transaction?.nonce === 1,
-  );
-  const hasPendingTransactions = filteredStxPendingTxData?.length > 0;
+    if (confirmedTransactions && confirmedTransactions.transactionsList.length > 0) {
+      nonce = confirmedTransactions.transactionsList[0].nonce + 1;
+    }
+    const currentPendingNonce =
+      (stxPendingTxData?.pendingTransactions ?? []).reduce(
+        (maxNonce, transaction) => Math.max(maxNonce, transaction?.nonce ?? 0),
+        0,
+      ) + 1;
+
+    return Math.max(currentPendingNonce, nonce);
+  };
+
+  useEffect(() => {
+    (async () => {
+      const currentNonce = await getAccountCurrentNonce();
+      const filteredStxPendingTxData = stxPendingTxData?.pendingTransactions.filter(
+        (transaction) => currentNonce - transaction?.nonce === 1,
+      );
+
+      setHasPendingTransactions(filteredStxPendingTxData?.length > 0);
+    })();
+  }, [stxPendingTxData]);
 
   return {
     isSponsored: userOverrideSponsorValue && isServiceRunning && !hasPendingTransactions,

--- a/src/app/screens/swap/useAlexSponsoredTransaction.ts
+++ b/src/app/screens/swap/useAlexSponsoredTransaction.ts
@@ -25,7 +25,16 @@ export const useAlexSponsoredTransaction = (userOverrideSponsorValue: boolean) =
     alexSDK.broadcastSponsoredTx(signed.serialize().toString('hex'));
 
   const { data: stxPendingTxData } = useStxPendingTxData();
-  const hasPendingTransactions = stxPendingTxData?.pendingTransactions?.length > 0;
+  const currentNonce =
+    (stxPendingTxData?.pendingTransactions ?? []).reduce(
+      (maxNonce, transaction) => Math.max(maxNonce, transaction?.nonce ?? 0),
+      0,
+    ) + 1;
+
+  const filteredStxPendingTxData = stxPendingTxData?.pendingTransactions.filter(
+    (transaction) => currentNonce - transaction?.nonce === 1,
+  );
+  const hasPendingTransactions = filteredStxPendingTxData?.length > 0;
 
   return {
     isSponsored: userOverrideSponsorValue && isServiceRunning && !hasPendingTransactions,

--- a/src/app/screens/swap/useAlexSponsoredTransaction.ts
+++ b/src/app/screens/swap/useAlexSponsoredTransaction.ts
@@ -27,7 +27,7 @@ export const useAlexSponsoredTransaction = (userOverrideSponsorValue: boolean) =
     alexSDK.broadcastSponsoredTx(signed.serialize().toString('hex'));
 
   const { data: stxPendingTxData } = useStxPendingTxData();
-  const pendingTransactionNonce =
+  const upcomingPendingTransactionNonce =
     (stxPendingTxData?.pendingTransactions ?? []).reduce(
       (maxNonce, transaction) => Math.max(maxNonce, transaction?.nonce ?? 0),
       0,
@@ -35,7 +35,7 @@ export const useAlexSponsoredTransaction = (userOverrideSponsorValue: boolean) =
 
   let hasPendingTransactions = false;
   //ignore pending transactions if account nonce has advanced pass the nonce in pending transactions
-  if (stxNonce > pendingTransactionNonce) {
+  if (stxNonce > upcomingPendingTransactionNonce) {
     hasPendingTransactions = false;
   } else {
     hasPendingTransactions = stxPendingTxData?.pendingTransactions?.length > 0;

--- a/src/app/screens/swap/useAlexSponsoredTransaction.ts
+++ b/src/app/screens/swap/useAlexSponsoredTransaction.ts
@@ -1,14 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import {
-  getConfirmedTransactions,
-  StacksTransaction,
-  StxTransactionListData,
-} from '@secretkeylabs/xverse-core';
+import { StacksTransaction } from '@secretkeylabs/xverse-core';
 import { AlexSDK } from 'alex-sdk';
 import useStxPendingTxData from '@hooks/queries/useStxPendingTxData';
 import useWalletSelector from '@hooks/useWalletSelector';
-import useNetworkSelector from '@hooks/useNetwork';
 
 const useAlexSponsorSwapEnabledQuery = (alexSDK: AlexSDK) =>
   useQuery({
@@ -19,11 +14,9 @@ const useAlexSponsorSwapEnabledQuery = (alexSDK: AlexSDK) =>
 export const useAlexSponsoredTransaction = (userOverrideSponsorValue: boolean) => {
   const alexSDK = useRef(new AlexSDK()).current;
   const [isServiceRunning, setIsServiceRunning] = useState(false);
-  const [hasPendingTransactions, setHasPendingTransactions] = useState(false);
   const { error, data: isEnabled, isLoading } = useAlexSponsorSwapEnabledQuery(alexSDK);
-  const { stxAddress } = useWalletSelector();
-  const selectedNetwork = useNetworkSelector();
-  const { data: stxPendingTxData } = useStxPendingTxData();
+  const { stxNonce } = useWalletSelector();
+  let hasPendingTransactions = false;
 
   useEffect(() => {
     if (!isLoading && !error) {
@@ -34,36 +27,16 @@ export const useAlexSponsoredTransaction = (userOverrideSponsorValue: boolean) =
   const sponsorTransaction = async (signed: StacksTransaction) =>
     alexSDK.broadcastSponsoredTx(signed.serialize().toString('hex'));
 
-  const getAccountCurrentNonce = async () => {
-    let nonce = 0;
-    const confirmedTransactions: StxTransactionListData = await getConfirmedTransactions({
-      stxAddress,
-      network: selectedNetwork,
-    });
+  const { data: stxPendingTxData } = useStxPendingTxData();
+  const pendingTransactionNonce =
+    stxPendingTxData?.pendingTransactions && stxPendingTxData?.pendingTransactions[0]?.nonce + 1;
 
-    if (confirmedTransactions && confirmedTransactions.transactionsList.length > 0) {
-      nonce = confirmedTransactions.transactionsList[0].nonce + 1;
-    }
-    const currentPendingNonce =
-      (stxPendingTxData?.pendingTransactions ?? []).reduce(
-        (maxNonce, transaction) => Math.max(maxNonce, transaction?.nonce ?? 0),
-        0,
-      ) + 1;
-
-    return Math.max(currentPendingNonce, nonce);
-  };
-
-  useEffect(() => {
-    (async () => {
-      const currentNonce = await getAccountCurrentNonce();
-      const filteredStxPendingTxData = stxPendingTxData?.pendingTransactions.filter(
-        (transaction) => currentNonce - transaction?.nonce === 1,
-      );
-
-      setHasPendingTransactions(filteredStxPendingTxData?.length > 0);
-    })();
-  }, [stxPendingTxData]);
-
+  //ignore pending transactions if account nonce has advanced pass the nonce in pending transactions
+  if (stxNonce > pendingTransactionNonce) {
+    hasPendingTransactions = false;
+  } else {
+    hasPendingTransactions = stxPendingTxData?.pendingTransactions?.length > 0;
+  }
   return {
     isSponsored: userOverrideSponsorValue && isServiceRunning && !hasPendingTransactions,
     isServiceRunning,

--- a/src/app/screens/swap/useAlexSponsoredTransaction.ts
+++ b/src/app/screens/swap/useAlexSponsoredTransaction.ts
@@ -16,7 +16,6 @@ export const useAlexSponsoredTransaction = (userOverrideSponsorValue: boolean) =
   const [isServiceRunning, setIsServiceRunning] = useState(false);
   const { error, data: isEnabled, isLoading } = useAlexSponsorSwapEnabledQuery(alexSDK);
   const { stxNonce } = useWalletSelector();
-  let hasPendingTransactions = false;
 
   useEffect(() => {
     if (!isLoading && !error) {
@@ -29,8 +28,12 @@ export const useAlexSponsoredTransaction = (userOverrideSponsorValue: boolean) =
 
   const { data: stxPendingTxData } = useStxPendingTxData();
   const pendingTransactionNonce =
-    stxPendingTxData?.pendingTransactions && stxPendingTxData?.pendingTransactions[0]?.nonce + 1;
+    (stxPendingTxData?.pendingTransactions ?? []).reduce(
+      (maxNonce, transaction) => Math.max(maxNonce, transaction?.nonce ?? 0),
+      0,
+    ) + 1;
 
+  let hasPendingTransactions = false;
   //ignore pending transactions if account nonce has advanced pass the nonce in pending transactions
   if (stxNonce > pendingTransactionNonce) {
     hasPendingTransactions = false;


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background
ALEX's sponsor service tries to broadcast replace by fee transactions and that probably causes an issue on the Stacks API. Creating dead pending transactions which results in user's not being able to use sponsored option for alex swap as it always indicates that there is a transaction pending

Issue Link: #[i[ENG-2589](https://linear.app/xverseapp/issue/ENG-2589/filter-out-dead-pending-transactions)]
Context Link (if applicable):

# 🔄 Changes
To filter out dead pending transactions, we first retrieve the account's current nonce. 

To obtain the account's current nonce, relying solely on pending transactions is insufficient. This is because, in the case of a dead pending sponsor transaction, the user might have initiated other transactions (both pending and confirmed). These transactions would have nonces greater than that of the dead transaction. Therefore, we retrieve the nonce of the confirmed transactions using the state from redux. If transactions made after the dead pending transaction have been confirmed, then the current account nonce would be one value greater than the nonce of the latest confirmed transaction.

Once we have obtained the account's current nonce, we check if it's greater than the pending transaction nonce. If yes we ignore the pending transactions. If not then the pending transactions are checked 

# 🖼 Screenshot / 📹 Video

While opening up PR, I tested with address `SP20B8SK3STWVAP8QPTQH5FSP6YTJBY3M6CNS6BK0` which had a dead pending swap transaction broadcasted 21 hours ago. I had made a few transactions after the dead pending one and all of them were confirmed.  The video below shows how before the fix, the sponsor toggle was off as it showed that there are pending transactions. The after video depicts how the sis enabledion is enables and the dead pending transaction is ignored
**Before**



https://github.com/secretkeylabs/xverse-web-extension/assets/88320460/a610c79f-d70f-4ea4-953c-1708bde4208d




**After**

https://github.com/secretkeylabs/xverse-web-extension/assets/88320460/6a62b33f-a871-48e2-b086-5a68d3ba39e5


# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.



