### PR TITLE
fix: account select navigation

### DIFF
--- a/src/app/screens/accountList/index.tsx
+++ b/src/app/screens/accountList/index.tsx
@@ -1,18 +1,18 @@
+import ConnectLedger from '@assets/img/dashboard/connect_ledger.svg';
+import Plus from '@assets/img/dashboard/plus.svg';
 import AccountRow from '@components/accountRow';
+import Separator from '@components/separator';
 import TopRow from '@components/topRow';
+import { useResetUserFlow } from '@hooks/useResetUserFlow';
+import useWalletReducer from '@hooks/useWalletReducer';
+import useWalletSelector from '@hooks/useWalletSelector';
+import { Account } from '@secretkeylabs/xverse-core/types';
+import { selectAccount } from '@stores/wallet/actions/actionCreators';
+import React, { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import Plus from '@assets/img/dashboard/plus.svg';
-import ConnectLedger from '@assets/img/dashboard/connect_ledger.svg';
-import { useDispatch } from 'react-redux';
-import { selectAccount } from '@stores/wallet/actions/actionCreators';
-import Separator from '@components/separator';
-import { Account } from '@secretkeylabs/xverse-core/types';
-import useWalletSelector from '@hooks/useWalletSelector';
-import useWalletReducer from '@hooks/useWalletReducer';
-import React, { useEffect, useMemo } from 'react';
-import { useResetUserFlow } from '@hooks/useResetUserFlow';
 
 const Container = styled.div`
   display: flex;
@@ -114,7 +114,7 @@ function AccountList(): JSX.Element {
       ),
     );
     broadcastResetUserFlow();
-    navigate('/');
+    navigate(-1);
   };
 
   const isAccountSelected = (account: Account) =>
@@ -122,7 +122,7 @@ function AccountList(): JSX.Element {
     account.stxAddress === selectedAccount?.stxAddress;
 
   const handleBackButtonClick = () => {
-    navigate('/');
+    navigate(-1);
   };
 
   const onCreateAccount = async () => {


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background
Selecting an account from the gallery view resulted in the wallet being opened up in full screen instead of going back to the gallery.

# 🔄 Changes
The account selection back button and after a new account is selected goes back to the previous page instead of to home.

# 🖼 Screenshot / 📹 Video
Include screenshots or a video demonstrating the changes. This is especially helpful for UI changes.

https://github.com/secretkeylabs/xverse-web-extension/assets/3322667/eac11589-3ce7-4317-9a03-2f62afd82bb8


# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
