### PR TITLE
feat: add Xverse namespaced providers

### DIFF
--- a/src/inpage/index.ts
+++ b/src/inpage/index.ts
@@ -1,5 +1,24 @@
-import StacksMethodsProvider from './stacks.inpage';
-import SatsMethodsProvider from './sats.inpage';
+import { StacksProvider } from '@stacks/connect';
+import { BitcoinProvider } from 'sats-connect';
 
+import SatsMethodsProvider from './sats.inpage';
+import StacksMethodsProvider from './stacks.inpage';
+
+declare global {
+  interface Window {
+    XverseProviders: {
+      StacksProvider: StacksProvider;
+      BitcoinProvider: BitcoinProvider;
+    };
+  }
+}
+
+// we keep this in case implementors call the default providers
 window.StacksProvider = StacksMethodsProvider;
 window.BitcoinProvider = SatsMethodsProvider;
+
+// and add this
+window.XverseProviders = {
+  StacksProvider: StacksMethodsProvider,
+  BitcoinProvider: SatsMethodsProvider,
+};

--- a/src/inpage/index.ts
+++ b/src/inpage/index.ts
@@ -13,11 +13,12 @@ declare global {
   }
 }
 
-// we keep this in case implementors call the default providers
+// we inject these in case implementors call the default providers
 window.StacksProvider = StacksMethodsProvider;
 window.BitcoinProvider = SatsMethodsProvider;
 
-// and add this
+// We also inject the providers in an Xverse object in order to have them exclusively available for Xverse wallet
+// and not clash with providers from other wallets
 window.XverseProviders = {
   StacksProvider: StacksMethodsProvider,
   BitcoinProvider: SatsMethodsProvider,


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Enhancement

# 📜 Background
Currently we only inject the default stacks and sats providers into the inpage window object. This clashes with other wallets which also inject it in the same place and integrators cannot force select Xverse when calling stacks/sats connect.

Issue Link: ENG-2732

# 🔄 Changes
This adds default Xverse providers in an Xverse namespace object on the window object.


# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
