### PR TITLE
fix: allow display of brc-20 if application/json type

### DIFF
--- a/src/app/screens/ordinals/brc20Tile.tsx
+++ b/src/app/screens/ordinals/brc20Tile.tsx
@@ -119,7 +119,7 @@ export default function Brc20Tile(props: Brc20TileProps) {
   } = props;
   const { t } = useTranslation('translation', { keyPrefix: 'NFT_DASHBOARD_SCREEN' });
   function renderFTIcon(ticker: string) {
-    const background = stc(ticker);
+    const background = stc(ticker.toUpperCase());
     ticker = ticker && ticker.substring(0, 4);
     return (
       <TickerIconContainer color={background} enlargeTicker={isGalleryOpen}>

--- a/src/app/screens/ordinals/ordinalImage.tsx
+++ b/src/app/screens/ordinals/ordinalImage.tsx
@@ -188,6 +188,25 @@ function OrdinalImage({
     return renderImage('BRC-721e', brc721eImage);
   }
 
+  if (
+    (ordinal?.content_type.includes('text/plain') ||
+      ordinal?.content_type.includes('application/json')) &&
+    textContent?.includes('brc-20')
+  ) {
+    return (
+      <ImageContainer>
+        <Brc20Tile
+          brcContent={textContent}
+          isGalleryOpen={isGalleryOpen}
+          isNftDashboard={isNftDashboard}
+          inNftDetail={inNftDetail}
+          isSmallImage={isSmallImage}
+          withoutSizeIncrease={withoutSizeIncrease}
+        />
+      </ImageContainer>
+    );
+  }
+
   if (ordinal?.content_type.includes('text')) {
     if (!textContent) {
       return (
@@ -197,20 +216,6 @@ function OrdinalImage({
       );
     }
 
-    if (textContent.includes('brc-20')) {
-      return (
-        <ImageContainer>
-          <Brc20Tile
-            brcContent={textContent}
-            isGalleryOpen={isGalleryOpen}
-            isNftDashboard={isNftDashboard}
-            inNftDetail={inNftDetail}
-            isSmallImage={isSmallImage}
-            withoutSizeIncrease={withoutSizeIncrease}
-          />
-        </ImageContainer>
-      );
-    }
     if (ordinal?.content_type.includes('html')) {
       return (
         <ImageContainer inNftDetail={inNftDetail}>
@@ -224,6 +229,7 @@ function OrdinalImage({
         </ImageContainer>
       );
     }
+
     return (
       <ImageContainer inNftDetail={inNftDetail} isGalleryOpen={isGalleryOpen}>
         <OrdinalContentText


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background
brc-20 inscriptions can be text/plain or applicaiton/json type. We only support text/plain at the moment.

brc-20 coin tickers (names) are also case agnostic but we generate different colour backgrounds if the case is different. 

Issue Link: ENG-2767

# ⚠️ Note
The fix makes all tickers of the same type the same colour, regardless of case, but it doesn't change the case of the ticker that was used when displaying the preview. Something to consider is that we could change all to lower/upper case for consistency.

# 🔄 Changes
- Added support for application/json BRC-20 inscriptions.
- Made colours consistent between different case BRC-20s.

# 🖼 Screenshot / 📹 Video
Before:
<img width="343" alt="image" src="https://github.com/secretkeylabs/xverse-web-extension/assets/3322667/0d8d608c-48f0-48ee-b230-cafe558c1b72">

After:
<img width="343" alt="image" src="https://github.com/secretkeylabs/xverse-web-extension/assets/3322667/7a4dab03-377f-44f0-83e7-199f4ac36e64">

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
