### PR TITLE
fix: don't show loader on balance refetch on home screen ENG-2757

### DIFF
--- a/src/app/screens/home/balanceCard/index.tsx
+++ b/src/app/screens/home/balanceCard/index.tsx
@@ -57,9 +57,9 @@ const BalanceContainer = styled.div((props) => ({
   gap: props.theme.spacing(5),
 }));
 
-const ReloadContainer = styled.div((props) => ({
-  marginBottom: props.theme.spacing(4),
-}));
+const ReloadContainer = styled.div({
+  marginBottom: 11,
+});
 
 interface BalanceCardProps {
   isLoading: boolean;
@@ -114,7 +114,7 @@ function BalanceCard(props: BalanceCardProps) {
 
         {isRefetching && !isLoading && (
           <ReloadContainer>
-            <MoonLoader color="white" size={15} />
+            <MoonLoader color="white" size={16} />
           </ReloadContainer>
         )}
       </BalanceContainer>

--- a/src/app/screens/home/balanceCard/index.tsx
+++ b/src/app/screens/home/balanceCard/index.tsx
@@ -1,12 +1,13 @@
-import BigNumber from 'bignumber.js';
-import styled from 'styled-components';
-import { microstacksToStx, satsToBtc } from '@secretkeylabs/xverse-core/currency';
-import { NumericFormat } from 'react-number-format';
 import BarLoader from '@components/barLoader';
-import { LoaderSize } from '@utils/constants';
-import { currencySymbolMap } from '@secretkeylabs/xverse-core/types/currency';
-import { useTranslation } from 'react-i18next';
 import useWalletSelector from '@hooks/useWalletSelector';
+import { microstacksToStx, satsToBtc } from '@secretkeylabs/xverse-core/currency';
+import { currencySymbolMap } from '@secretkeylabs/xverse-core/types/currency';
+import { LoaderSize } from '@utils/constants';
+import BigNumber from 'bignumber.js';
+import { useTranslation } from 'react-i18next';
+import { NumericFormat } from 'react-number-format';
+import { MoonLoader } from 'react-spinners';
+import styled from 'styled-components';
 
 const RowContainer = styled.div((props) => ({
   display: 'flex',
@@ -48,15 +49,28 @@ const CurrencyCard = styled.div((props) => ({
   marginLeft: props.theme.spacing(4),
 }));
 
+const BalanceContainer = styled.div((props) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'flex-start',
+  alignItems: 'flex-end',
+  gap: props.theme.spacing(5),
+}));
+
+const ReloadContainer = styled.div((props) => ({
+  marginBottom: props.theme.spacing(4),
+}));
+
 interface BalanceCardProps {
   isLoading: boolean;
+  isRefetching: boolean;
 }
 
 function BalanceCard(props: BalanceCardProps) {
   const { t } = useTranslation('translation', { keyPrefix: 'DASHBOARD_SCREEN' });
   const { fiatCurrency, btcFiatRate, stxBtcRate, stxBalance, btcBalance, btcAddress, stxAddress } =
     useWalletSelector();
-  const { isLoading } = props;
+  const { isLoading, isRefetching } = props;
 
   function calculateTotalBalance() {
     let totalBalance = new BigNumber(0);
@@ -83,19 +97,27 @@ function BalanceCard(props: BalanceCardProps) {
           <CurrencyText>{fiatCurrency}</CurrencyText>
         </CurrencyCard>
       </RowContainer>
-      {isLoading ? (
-        <BarLoaderContainer>
-          <BarLoader loaderSize={LoaderSize.LARGE} />
-        </BarLoaderContainer>
-      ) : (
-        <NumericFormat
-          value={calculateTotalBalance()}
-          displayType="text"
-          prefix={`${currencySymbolMap[fiatCurrency]}`}
-          thousandSeparator
-          renderText={(value: string) => <BalanceAmountText>{value}</BalanceAmountText>}
-        />
-      )}
+      <BalanceContainer>
+        {isLoading ? (
+          <BarLoaderContainer>
+            <BarLoader loaderSize={LoaderSize.LARGE} />
+          </BarLoaderContainer>
+        ) : (
+          <NumericFormat
+            value={calculateTotalBalance()}
+            displayType="text"
+            prefix={`${currencySymbolMap[fiatCurrency]}`}
+            thousandSeparator
+            renderText={(value: string) => <BalanceAmountText>{value}</BalanceAmountText>}
+          />
+        )}
+
+        {isRefetching && !isLoading && (
+          <ReloadContainer>
+            <MoonLoader color="white" size={15} />
+          </ReloadContainer>
+        )}
+      </BalanceContainer>
     </>
   );
 }

--- a/src/app/screens/home/index.tsx
+++ b/src/app/screens/home/index.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable no-await-in-loop */
-import styled from 'styled-components';
 import SIP10Icon from '@assets/img/dashboard/SIP10.svg';
 import ArrowDownLeft from '@assets/img/dashboard/arrow_down_left.svg';
 import ArrowUpRight from '@assets/img/dashboard/arrow_up_right.svg';
@@ -7,14 +6,15 @@ import BitcoinIcon from '@assets/img/dashboard/bitcoin_icon.svg';
 import BitcoinToken from '@assets/img/dashboard/bitcoin_token.svg';
 import CreditCard from '@assets/img/dashboard/credit_card.svg';
 import ListDashes from '@assets/img/dashboard/list_dashes.svg';
-import { Plus } from '@phosphor-icons/react';
 import ordinalsIcon from '@assets/img/dashboard/ordinalBRC20.svg';
-import Swap from '@assets/img/dashboard/swap.svg';
 import stacksIcon from '@assets/img/dashboard/stack_icon.svg';
+import Swap from '@assets/img/dashboard/swap.svg';
 import AccountHeaderComponent from '@components/accountHeader';
 import BottomModal from '@components/bottomModal';
+import ActionButton from '@components/button';
 import ReceiveCardComponent from '@components/receiveCardComponent';
-import { isLedgerAccount } from '@utils/helper';
+import ShowBtcReceiveAlert from '@components/showBtcReceiveAlert';
+import ShowOrdinalReceiveAlert from '@components/showOrdinalReceiveAlert';
 import BottomBar from '@components/tabBar';
 import TokenTile from '@components/tokenTile';
 import useAppConfig from '@hooks/queries/useAppConfig';
@@ -25,15 +25,15 @@ import useCoinRates from '@hooks/queries/useCoinRates';
 import useFeeMultipliers from '@hooks/queries/useFeeMultipliers';
 import useStxWalletData from '@hooks/queries/useStxWalletData';
 import useWalletSelector from '@hooks/useWalletSelector';
+import { Plus } from '@phosphor-icons/react';
 import CoinSelectModal from '@screens/home/coinSelectModal';
 import { FungibleToken } from '@secretkeylabs/xverse-core/types';
 import { CurrencyTypes } from '@utils/constants';
+import { isLedgerAccount } from '@utils/helper';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import ShowBtcReceiveAlert from '@components/showBtcReceiveAlert';
-import ShowOrdinalReceiveAlert from '@components/showOrdinalReceiveAlert';
-import ActionButton from '@components/button';
+import styled from 'styled-components';
 import Theme from 'theme';
 import BalanceCard from './balanceCard';
 import SquareButton from './squareButton';
@@ -396,11 +396,12 @@ function Home() {
       )}
       <Container>
         <BalanceCard
-          isLoading={
-            loadingStxWalletData ||
-            loadingBtcWalletData ||
-            refetchingStxWalletData ||
-            refetchingBtcWalletData
+          isLoading={loadingStxWalletData || loadingBtcWalletData}
+          isRefetching={
+            refetchingBtcCoinData ||
+            refetchingBtcWalletData ||
+            refetchingCoinData ||
+            refetchingStxWalletData
           }
         />
         <RowButtonContainer>
@@ -416,7 +417,7 @@ function Home() {
               title={t('BITCOIN')}
               currency="BTC"
               icon={BitcoinIcon}
-              loading={loadingBtcWalletData || refetchingBtcWalletData}
+              loading={loadingBtcWalletData}
               underlayColor={Theme.colors.background.elevation1}
               onPress={handleTokenPressed}
             />
@@ -426,7 +427,7 @@ function Home() {
               title={t('STACKS')}
               currency="STX"
               icon={stacksIcon}
-              loading={loadingStxWalletData || refetchingStxWalletData}
+              loading={loadingStxWalletData}
               underlayColor={Theme.colors.background.elevation1}
               onPress={handleTokenPressed}
             />
@@ -441,7 +442,7 @@ function Home() {
                   <TokenTile
                     title={coin.name}
                     currency="FT"
-                    loading={loadingCoinData || refetchingCoinData}
+                    loading={loadingCoinData}
                     underlayColor={Theme.colors.background.elevation1}
                     fungibleToken={coin}
                     onPress={handleTokenPressed}
@@ -452,7 +453,7 @@ function Home() {
                 key={coin.name}
                 title={coin.name}
                 currency="brc20"
-                loading={loadingBtcCoinData || refetchingBtcCoinData}
+                loading={loadingBtcCoinData}
                 underlayColor={Theme.colors.background.elevation1}
                 fungibleToken={coin}
                 onPress={handleTokenPressed}


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background
When the wallet is on the home screen, it often refetches balances and we display a loader. It also happens if you click off the popup and back onto it. It is a bit annoying and a lot of users have complained about it.

# 🔄 Changes
This changes how we calculate when to show the loader to only show it on the initial page load and not on a refetch.

# 🖼 Screenshot / 📹 Video
Before:

https://github.com/secretkeylabs/xverse-web-extension/assets/3322667/33817625-a2fa-4d8c-a2d3-0ea03f112ca0


After:


https://github.com/secretkeylabs/xverse-web-extension/assets/3322667/ef274be2-cf75-418c-8dbd-74e876d1c99e



# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
