### PR TITLE
fix: brc-20 balance number check

### DIFF
--- a/src/app/screens/sendBrc20/index.tsx
+++ b/src/app/screens/sendBrc20/index.tsx
@@ -1,20 +1,20 @@
-import styled from 'styled-components';
+import ActionButton from '@components/button';
+import BottomBar from '@components/tabBar';
+import TopRow from '@components/topRow';
+import { useResetUserFlow } from '@hooks/useResetUserFlow';
+import useWalletSelector from '@hooks/useWalletSelector';
+import {
+  ErrorCodes,
+  createBrc20TransferOrder,
+  getBtcFiatEquivalent,
+  signBtcTransaction,
+} from '@secretkeylabs/xverse-core';
+import { Recipient } from '@secretkeylabs/xverse-core/transactions/btc';
 import BigNumber from 'bignumber.js';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
-import {
-  createBrc20TransferOrder,
-  getBtcFiatEquivalent,
-  signBtcTransaction,
-  ErrorCodes,
-} from '@secretkeylabs/xverse-core';
-import { Recipient } from '@secretkeylabs/xverse-core/transactions/btc';
-import { useResetUserFlow } from '@hooks/useResetUserFlow';
-import useWalletSelector from '@hooks/useWalletSelector';
-import TopRow from '@components/topRow';
-import BottomBar from '@components/tabBar';
-import ActionButton from '@components/button';
+import styled from 'styled-components';
 import Brc20TransferForm from './brc20TransferForm';
 import Brc20TransferInfo from './brc20TransferInfo';
 
@@ -72,7 +72,12 @@ function SendBrc20Screen() {
   const fungibleToken =
     location.state?.fungibleToken || brcCoinsList?.find((coin) => coin.name === coinName);
 
-  const isSendButtonEnabled = amountToSend !== '' && amountToSend <= fungibleToken.balance;
+  const isSendButtonEnabled =
+    amountToSend !== '' &&
+    !Number.isNaN(Number(amountToSend)) &&
+    !Number.isNaN(Number(fungibleToken.balance)) &&
+    +amountToSend > 0 &&
+    +amountToSend <= +fungibleToken.balance;
   const isActionButtonEnabled = showForm ? isSendButtonEnabled : true;
 
   const { subscribeToResetUserFlow } = useResetUserFlow();


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background
We do a string check on the balance when sending BRC-20 and deciding whether to enable the next button or not. This results in a lexical check rather than a numeric one.

So, as an example, if you had a balance of 20000, the button would be disabled if you tried to send anything that began with a 3 or greater.

# 🔄 Changes
- Convert values to numbers before checking brc-20 balance
- Only affects the send BRC-20 screen where you select how much you want to send

# 🖼 Screenshot / 📹 Video
Include screenshots or a video demonstrating the changes. This is especially helpful for UI changes.

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
