### PR TITLE
fix: improve full screen popup styling

### DIFF
--- a/src/app/components/screenContainer/index.tsx
+++ b/src/app/components/screenContainer/index.tsx
@@ -34,7 +34,7 @@ function ScreenContainer(): JSX.Element {
   const { t } = useTranslation('translation');
 
   return (
-    <RouteContainer>
+    <RouteContainer className="optionsContainer">
       {network.type === 'Testnet' && (
         <TestnetContainer>
           <TestnetText>{t('SETTING_SCREEN.TESTNET')}</TestnetText>

--- a/src/pages/Options/index.css
+++ b/src/pages/Options/index.css
@@ -25,10 +25,11 @@ header h2 {
   width: 100vw;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  justify-content: safe center;
+  align-items: safe center;
 }
 
 #app {
+  max-height: 80vh;
   min-height: 600px;
 }

--- a/src/pages/Options/index.css
+++ b/src/pages/Options/index.css
@@ -20,6 +20,7 @@ header h2 {
   letter-spacing: 0em;
   text-align: right;
 }
+
 #app-container {
   height: 100vh;
   width: 100vw;
@@ -30,6 +31,9 @@ header h2 {
 }
 
 #app {
-  max-height: 80vh;
   min-height: 600px;
+}
+
+.optionsContainer {
+  height: 600px !important;
 }


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background
The styling of the popup views in fullscreen (options) mode makes the popup extend to full height instead of going into overflow mode.

# 🔄 Changes
Changed the styling to limit it to 80vh with a minimum height of 600px.


# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
