### PR TITLE
fix: don't show fees until we have UTXOs on inscription screen

### DIFF
--- a/src/app/screens/createInscription/index.tsx
+++ b/src/app/screens/createInscription/index.tsx
@@ -226,7 +226,7 @@ function CreateInscription() {
     commitValue,
     commitValueBreakdown,
     errorCode: feeErrorCode,
-    isLoading,
+    isLoading: inscriptionFeesLoading,
   } = useInscriptionFees({
     addressUtxos: utxos,
     content,
@@ -309,6 +309,8 @@ function CreateInscription() {
   }
 
   const errorCode = feeErrorCode || executeErrorCode;
+
+  const isLoading = utxos === undefined || inscriptionFeesLoading;
 
   return (
     <ConfirmScreen


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background
We show fees before we have UTXOs in the inscription screen resulting in a flash when we actually get the UTXOs and recalculate.

# 🔄 Changes
Keeps the state as loading until the UTXOs are pulled.

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
