### PR TITLE
Use `ticker` field instead of `name` for ft and brc-20 token sending

### DIFF
--- a/src/app/components/sendForm/index.tsx
+++ b/src/app/components/sendForm/index.tsx
@@ -332,6 +332,7 @@ function SendForm({
             .toFixed(fungibleToken.decimals ?? 2)
             .toString();
         }
+        return '';
       default:
         return '';
     }

--- a/src/app/components/smallActionButton/index.tsx
+++ b/src/app/components/smallActionButton/index.tsx
@@ -14,9 +14,9 @@ const Button = styled.div<ButtonProps>((props) => ({
     : props.theme.colors.action.classic,
   width: 48,
   height: 48,
-  transition: 'all 0.2s ease',
+  transition: 'background-color 0.2s ease, opacity 0.2s ease',
   ':hover': {
-    background: props.isOpaque
+    backgroundColor: props.isOpaque
       ? props.theme.colors.background.elevation2
       : props.theme.colors.action.classicLight,
     opacity: props.isOpaque ? 0.85 : 0.6,
@@ -44,6 +44,7 @@ const ButtonText = styled.h1((props) => ({
 const ButtonImage = styled.img({
   alignSelf: 'center',
   transform: 'all',
+  transition: 'all 0.2s ease',
 });
 
 interface ButtonContainerProps {

--- a/src/app/screens/coinDashboard/coinHeader.tsx
+++ b/src/app/screens/coinDashboard/coinHeader.tsx
@@ -276,12 +276,14 @@ export default function CoinHeader(props: CoinBalanceProps) {
           return;
         case 'FT':
           await chrome.tabs.create({
-            url: chrome.runtime.getURL(`options.html#/send-ft?coinName=${fungibleToken?.name}`),
+            url: chrome.runtime.getURL(`options.html#/send-ft?coinTicker=${fungibleToken?.ticker}`),
           });
           return;
         case 'brc20':
           await chrome.tabs.create({
-            url: chrome.runtime.getURL(`options.html#/send-brc20?coinName=${fungibleToken?.name}`),
+            url: chrome.runtime.getURL(
+              `options.html#/send-brc20?coinTicker=${fungibleToken?.ticker}`,
+            ),
           });
           return;
         default:

--- a/src/app/screens/home/index.tsx
+++ b/src/app/screens/home/index.tsx
@@ -251,7 +251,7 @@ function Home() {
     }
     if (isLedgerAccount(selectedAccount)) {
       await chrome.tabs.create({
-        url: chrome.runtime.getURL(`options.html#/send-ft?coinName=${coin.name}`),
+        url: chrome.runtime.getURL(`options.html#/send-ft?coinTicker=${coin.ticker}`),
       });
       return;
     }

--- a/src/app/screens/home/squareButton/index.tsx
+++ b/src/app/screens/home/squareButton/index.tsx
@@ -12,6 +12,7 @@ const Button = styled.button`
   border-radius: 16px;
   justify-content: center;
   align-items: center;
+  transition: background-color 0.2s ease, opacity 0.2s ease;
   background-color: ${(props) => props.theme.colors.action.classic};
   :hover {
     background-color: ${(props) => props.theme.colors.action.classicLight};

--- a/src/app/screens/sendBrc20/index.tsx
+++ b/src/app/screens/sendBrc20/index.tsx
@@ -68,9 +68,9 @@ function SendBrc20Screen() {
   const [showForm, setShowForm] = useState(false);
   const location = useLocation();
 
-  const coinName = location.search ? location.search.split('coinName=')[1] : undefined;
+  const coinTicker = location.search ? location.search.split('coinTicker=')[1] : undefined;
   const fungibleToken =
-    location.state?.fungibleToken || brcCoinsList?.find((coin) => coin.name === coinName);
+    location.state?.fungibleToken || brcCoinsList?.find((coin) => coin.ticker === coinTicker);
 
   const isSendButtonEnabled =
     amountToSend !== '' &&

--- a/src/app/screens/sendFt/index.tsx
+++ b/src/app/screens/sendFt/index.tsx
@@ -27,9 +27,9 @@ function SendFtScreen() {
   const location = useLocation();
   const selectedNetwork = useNetworkSelector();
 
-  const coinName = location.search ? location.search.split('coinName=')[1] : undefined;
+  const coinTicker = location.search ? location.search.split('coinTicker=')[1] : undefined;
   const fungibleToken =
-    location.state?.fungibleToken || coinsList?.find((coin) => coin.name === coinName);
+    location.state?.fungibleToken || coinsList?.find((coin) => coin.ticker === coinTicker);
 
   let recipientAddress: string | undefined;
   let ftAmountToSend: string | undefined;


### PR DESCRIPTION
# 🔘 PR Type
- [x] Bugfix

# 📜 Background
We have an issue with finding the right token for ledger sending flow as it uses the `name` field which may contain some symbols that are not recognized when matching the coin name from the URL with the coin name in array which results in this:
![image (3)](https://github.com/secretkeylabs/xverse-web-extension/assets/36603049/3ac2de3e-4a8e-4869-a127-563294cb9975)

Issue Link: #[issue_number]
Context Link (if applicable):

# 🔄 Changes
- Changed the field that we use to find the token from `name` to `ticker`
- Fixed the transition for buttons on the main dashboard

Impact:
- This PR impacts `/send-brc20` and `/send-ft` pages

# 🖼 Screenshot / 📹 Video
<img width="1908" alt="Monosnap Xverse Wallet 2023-09-07 17-16-05" src="https://github.com/secretkeylabs/xverse-web-extension/assets/36603049/0160ab63-c6fe-4546-a5d3-f9906110f808">

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
