### PR TITLE
fix: send through app fees when inscripting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ledgerhq/hw-transport-webusb": "^6.27.13",
         "@phosphor-icons/react": "^2.0.10",
         "@react-spring/web": "^9.6.1",
-        "@secretkeylabs/xverse-core": "^1.7.3",
+        "@secretkeylabs/xverse-core": "1.7.3",
         "@stacks/connect": "^6.10.2",
         "@stacks/encryption": "4.3.5",
         "@stacks/stacks-blockchain-api-types": "^6.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ledgerhq/hw-transport-webusb": "^6.27.13",
         "@phosphor-icons/react": "^2.0.10",
         "@react-spring/web": "^9.6.1",
-        "@secretkeylabs/xverse-core": "^1.7.0-a45f1f7",
+        "@secretkeylabs/xverse-core": "^1.7.3",
         "@stacks/connect": "^6.10.2",
         "@stacks/encryption": "4.3.5",
         "@stacks/stacks-blockchain-api-types": "^6.1.1",
@@ -2211,9 +2211,9 @@
       }
     },
     "node_modules/@secretkeylabs/xverse-core": {
-      "version": "1.7.0-a45f1f7",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.7.0-a45f1f7/9fc7f22d42d9efacd7e08d78103540ba47f3fdb2",
-      "integrity": "sha512-/wXlZ3DrOFkaeJ2qvUCAoo0YClUCVr+Or3q4gQAEK+ZwoQJqAwVFd54yuIiX9U4WB88bZAo1Nw2OG+2EtwIk8g==",
+      "version": "1.7.3",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.7.3/cfdee30fbb06048b309604b82160d97d356252d1",
+      "integrity": "sha512-CEPA0TOtK2t8d3OIZZmzTfxeDepgmuXYqxVne+TRrMxMaW1De2uiiQrhtSxefrUTP0lMUxhNxKQHd7HnUPD2hg==",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
@@ -20383,9 +20383,9 @@
       }
     },
     "@secretkeylabs/xverse-core": {
-      "version": "1.7.0-a45f1f7",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.7.0-a45f1f7/9fc7f22d42d9efacd7e08d78103540ba47f3fdb2",
-      "integrity": "sha512-/wXlZ3DrOFkaeJ2qvUCAoo0YClUCVr+Or3q4gQAEK+ZwoQJqAwVFd54yuIiX9U4WB88bZAo1Nw2OG+2EtwIk8g==",
+      "version": "1.7.3",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.7.3/cfdee30fbb06048b309604b82160d97d356252d1",
+      "integrity": "sha512-CEPA0TOtK2t8d3OIZZmzTfxeDepgmuXYqxVne+TRrMxMaW1De2uiiQrhtSxefrUTP0lMUxhNxKQHd7HnUPD2hg==",
       "requires": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
         "@noble/secp256k1": "^1.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ledgerhq/hw-transport-webusb": "^6.27.13",
         "@phosphor-icons/react": "^2.0.10",
         "@react-spring/web": "^9.6.1",
-        "@secretkeylabs/xverse-core": "1.7.2",
+        "@secretkeylabs/xverse-core": "^1.7.0-a45f1f7",
         "@stacks/connect": "^6.10.2",
         "@stacks/encryption": "4.3.5",
         "@stacks/stacks-blockchain-api-types": "^6.1.1",
@@ -2211,9 +2211,9 @@
       }
     },
     "node_modules/@secretkeylabs/xverse-core": {
-      "version": "1.7.2",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.7.2/b47baff054a70600b61da1dd8fcb03bb65b7da2f",
-      "integrity": "sha512-mmxLHkPZ3kZ+4zOrDI6Z3ietExlARpD0mLEhg0ioUayA5QUGnXAtbo7nESD4g6Rc+5cICmZir5qnAeAE7QxtEA==",
+      "version": "1.7.0-a45f1f7",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.7.0-a45f1f7/9fc7f22d42d9efacd7e08d78103540ba47f3fdb2",
+      "integrity": "sha512-/wXlZ3DrOFkaeJ2qvUCAoo0YClUCVr+Or3q4gQAEK+ZwoQJqAwVFd54yuIiX9U4WB88bZAo1Nw2OG+2EtwIk8g==",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
@@ -20383,9 +20383,9 @@
       }
     },
     "@secretkeylabs/xverse-core": {
-      "version": "1.7.2",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.7.2/b47baff054a70600b61da1dd8fcb03bb65b7da2f",
-      "integrity": "sha512-mmxLHkPZ3kZ+4zOrDI6Z3ietExlARpD0mLEhg0ioUayA5QUGnXAtbo7nESD4g6Rc+5cICmZir5qnAeAE7QxtEA==",
+      "version": "1.7.0-a45f1f7",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/1.7.0-a45f1f7/9fc7f22d42d9efacd7e08d78103540ba47f3fdb2",
+      "integrity": "sha512-/wXlZ3DrOFkaeJ2qvUCAoo0YClUCVr+Or3q4gQAEK+ZwoQJqAwVFd54yuIiX9U4WB88bZAo1Nw2OG+2EtwIk8g==",
       "requires": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
         "@noble/secp256k1": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@ledgerhq/hw-transport-webusb": "^6.27.13",
     "@phosphor-icons/react": "^2.0.10",
     "@react-spring/web": "^9.6.1",
-    "@secretkeylabs/xverse-core": "^1.7.3",
+    "@secretkeylabs/xverse-core": "1.7.3",
     "@stacks/connect": "^6.10.2",
     "@stacks/encryption": "4.3.5",
     "@stacks/stacks-blockchain-api-types": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@ledgerhq/hw-transport-webusb": "^6.27.13",
     "@phosphor-icons/react": "^2.0.10",
     "@react-spring/web": "^9.6.1",
-    "@secretkeylabs/xverse-core": "1.7.2",
+    "@secretkeylabs/xverse-core": "^1.7.0-a45f1f7",
     "@stacks/connect": "^6.10.2",
     "@stacks/encryption": "4.3.5",
     "@stacks/stacks-blockchain-api-types": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@ledgerhq/hw-transport-webusb": "^6.27.13",
     "@phosphor-icons/react": "^2.0.10",
     "@react-spring/web": "^9.6.1",
-    "@secretkeylabs/xverse-core": "^1.7.0-a45f1f7",
+    "@secretkeylabs/xverse-core": "^1.7.3",
     "@stacks/connect": "^6.10.2",
     "@stacks/encryption": "4.3.5",
     "@stacks/stacks-blockchain-api-types": "^6.1.1",

--- a/src/app/screens/createInscription/index.tsx
+++ b/src/app/screens/createInscription/index.tsx
@@ -254,6 +254,8 @@ function CreateInscription() {
     seedPhrase,
     contentBase64: payloadType === 'BASE_64' ? content : undefined,
     contentString: payloadType === 'PLAIN_TEXT' ? content : undefined,
+    serviceFee: appFee,
+    serviceFeeAddress: appFeeAddress,
   });
 
   const cancelCallback = () => {


### PR DESCRIPTION
# 🔘 PR Type

What kind of change does this PR introduce?

- [x] Bugfix

# 📜 Background
App fees were not being sent to the apps in the inscription service requests.

Issue Link: #596 

# 🔄 Changes
Enumerate the changes made in this pull request, detailing what has been modified, added, or removed. Include technical details and implications if necessary.

Impact:
- App fees are now sent through with inscription requests

# 🖼 Examples
With 10k app fees:
https://mempool.space/tx/fe304d6f356c13917ab90456beb9aafcf73a12fb23490eaaa2a083e2fcf0e1a6#flow=&vout=0

With no app fees:
https://mempool.space/tx/598f94c6b52007cdd857d70a48034d199960f3c8d95ed5d301d5469ed407724f#flow=&vout=0

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
