### PR TITLE
Make `Authorize data collection` property turned on by default

### DIFF
--- a/src/app/screens/legalLinks/index.tsx
+++ b/src/app/screens/legalLinks/index.tsx
@@ -64,9 +64,9 @@ const SwitchContainer = styled.div((props) => ({
   fontSize: '0.875rem',
 }));
 
-const DataCollectionDescription = styled.div((props) => ({
+const DataCollectionDescription = styled.p((props) => ({
   ...props.theme.body_m,
-  color: props.theme.colors.white['200'],
+  color: props.theme.colors.white_200,
   marginTop: props.theme.spacing(32),
 }));
 

--- a/src/app/screens/legalLinks/index.tsx
+++ b/src/app/screens/legalLinks/index.tsx
@@ -64,6 +64,12 @@ const SwitchContainer = styled.div((props) => ({
   fontSize: '0.875rem',
 }));
 
+const DataCollectionDescription = styled.div((props) => ({
+  ...props.theme.body_m,
+  color: props.theme.colors.white['200'],
+  marginTop: props.theme.spacing(32),
+}));
+
 function LegalLinks() {
   const { t } = useTranslation('translation', { keyPrefix: 'LEGAL_SCREEN' });
   const navigate = useNavigate();
@@ -71,7 +77,7 @@ function LegalLinks() {
   const { selectedAccount } = useWalletSelector();
   const [searchParams] = useSearchParams();
   const theme = useTheme();
-  const [isToggleEnabled, setIsToggleEnabled] = useState(false);
+  const [isToggleEnabled, setIsToggleEnabled] = useState(true);
 
   const handleSwitchToggle = () => setIsToggleEnabled((prevEnabledState) => !prevEnabledState);
 
@@ -105,9 +111,11 @@ function LegalLinks() {
             {t('PRIVACY_POLICY_LINK_BUTTON')}
             <img src={LinkIcon} alt="privacy" />
           </CustomizedLink>
-          <Separator />
+          <DataCollectionDescription>
+            {t('AUTHORIZE_DATA_COLLECTION.DESCRIPTION')}
+          </DataCollectionDescription>
           <SwitchContainer>
-            <div>{t('AUTHORIZE_DATA_COLLECTION')}</div>
+            <div>{t('AUTHORIZE_DATA_COLLECTION.TITLE')}</div>
             <CustomSwitch
               onColor={theme.colors.orange_main}
               offColor={theme.colors.background.elevation3}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -397,7 +397,10 @@
     "TERMS_SERVICES_LINK_BUTTON": "Terms of Service",
     "PRIVACY_POLICY_LINK_BUTTON": "Privacy Policy",
     "ACCEPT_LEGAL_BUTTON": "Accept",
-    "AUTHORIZE_DATA_COLLECTION": "Authorize data collection"
+    "AUTHORIZE_DATA_COLLECTION": {
+      "TITLE": "Authorize data collection",
+      "DESCRIPTION": "We would like to collect anonymous usage data to better understand users and improve the app. You can change this setting at any time."
+    }
   },
   "BACKUP_WALLET_SCREEN": {
     "SCREEN_TITLE": "Backup your wallet",


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

- [x] Enhancement

# 📜 Background
We want to make the `Authorize data collection` property turned on by default. And we'd also like to add the description for the data collection on the Legal screen.

Issue Link: #[[ENG-3000](https://linear.app/xverseapp/issue/ENG-3000/make-authorize-data-collection-property-turned-on-by-default)]
Context Link (if applicable): https://secretkeylabs.slack.com/archives/C05QCJM9D1N/p1696433854123279

# 🔄 Changes
- Made the `Authorize data collection` property turned on by default on the Legal screen.
- Added the description for that property.

Impact:
- This PR impacts the Legal screen and the mixpanel data tracking logic.

# 🖼 Screenshot / 📹 Video
<img width="430" alt="Monosnap Xverse Wallet 2023-10-11 16-51-04" src="https://github.com/secretkeylabs/xverse-web-extension/assets/36603049/daf1eef3-f21a-4f77-9220-905d6a81f519">

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
