### PR TITLE
feat: allow unpublished UTXOs as inputs to PSBTs

### DIFF
--- a/src/app/hooks/useDetectOrdinalInSignPsbt.ts
+++ b/src/app/hooks/useDetectOrdinalInSignPsbt.ts
@@ -1,5 +1,6 @@
 import { getUtxoOrdinalBundle, ParsedPSBT } from '@secretkeylabs/xverse-core';
 import { BundleItem, mapRareSatsAPIResponseToRareSats } from '@utils/rareSats';
+import { isAxiosError } from 'axios';
 import { useEffect, useState } from 'react';
 import useWalletSelector from './useWalletSelector';
 
@@ -15,21 +16,30 @@ const useDetectOrdinalInSignPsbt = (parsedPsbt: '' | ParsedPSBT) => {
       setLoading(true);
       await Promise.all(
         parsedPsbt.inputs.map(async (input) => {
-          const data = await getUtxoOrdinalBundle(input.txid, input.index);
-          console.log({ data });
+          try {
+            const data = await getUtxoOrdinalBundle(input.txid, input.index);
 
-          const bundle = mapRareSatsAPIResponseToRareSats(data);
-          bundle.items.forEach((item) => {
-            // we don't show unknown items for now
-            if (item.type === 'unknown') {
-              return;
+            const bundle = mapRareSatsAPIResponseToRareSats(data);
+            bundle.items.forEach((item) => {
+              // we don't show unknown items for now
+              if (item.type === 'unknown') {
+                return;
+              }
+              bundleItems.push(item);
+            });
+          } catch (e) {
+            // we get back a 404 if the UTXO is not found, so it is likely this is a UTXO from an unpublished txn
+            if (!isAxiosError(e) || e.status !== 404) {
+              // rethrow error if response was not 404
+              throw e;
             }
-            bundleItems.push(item);
-          });
+          }
         }),
       );
+
       setBundleItemsData(bundleItems);
       setLoading(false);
+
       parsedPsbt.outputs.forEach(async (output) => {
         if (output.address === ordinalsAddress) {
           setUserReceivesOrdinal(true);

--- a/src/app/hooks/useDetectOrdinalInSignPsbt.ts
+++ b/src/app/hooks/useDetectOrdinalInSignPsbt.ts
@@ -29,7 +29,7 @@ const useDetectOrdinalInSignPsbt = (parsedPsbt: '' | ParsedPSBT) => {
             });
           } catch (e) {
             // we get back a 404 if the UTXO is not found, so it is likely this is a UTXO from an unpublished txn
-            if (!isAxiosError(e) || e.status !== 404) {
+            if (!isAxiosError(e) || e.response?.status !== 404) {
               // rethrow error if response was not 404
               throw e;
             }


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

- [x] Bugfix

# 📜 Background
We received a bug report form a market place that their PSBT signing stopped working. They narrowed it down to the bundle call failing with a 400/404 when the app tried to check if there were any inscribed/rare sats in the UTXO and the UTXO didn't exist yet as it was an output of an unpublished txn.

# 🔄 Changes
Check for a 404 response from the backend for non-existent UTXOs and ignore it when checking for ordinals in a PSBT signing request UTXO.

# Testing
To test, run this branch alongside the sats-connect example app. On the sign transaction component, go to the utils file with the createPSBT function and change the txid of the UTXO from the payment address to a random, non-existent tx id (line 71).

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
