### PR TITLE
fix: disabling ordinals user should not see them in the

### DIFF
--- a/src/app/screens/nftDashboard/collectiblesTabs.tsx
+++ b/src/app/screens/nftDashboard/collectiblesTabs.tsx
@@ -126,7 +126,6 @@ export default function CollectiblesTabs({
     hasActivatedOrdinalsKey,
     showNoticeAlert,
     onDismissRareSatsNotice,
-    onLoadMoreRareSatsButtonClick,
     stacksNftsQuery,
     inscriptionsQuery,
   } = nftDashboard;
@@ -237,7 +236,7 @@ export default function CollectiblesTabs({
                 text={t('LOAD_MORE')}
                 processing={rareSatsQuery.isFetchingNextPage}
                 disabled={rareSatsQuery.isFetchingNextPage}
-                onPress={onLoadMoreRareSatsButtonClick}
+                onPress={rareSatsQuery.fetchNextPage}
               />
             </LoadMoreButtonContainer>
           )}

--- a/src/app/screens/nftDashboard/collectiblesTabs.tsx
+++ b/src/app/screens/nftDashboard/collectiblesTabs.tsx
@@ -119,11 +119,11 @@ export default function CollectiblesTabs({
   const [tabIndex, setTabIndex] = useState(tabKeyToIndex(searchParams?.get('tab')));
   const {
     isGalleryOpen,
-    hasActivatedOrdinalsKey,
     rareSatsQuery,
     totalNfts,
     totalInscriptions,
     hasActivatedRareSatsKey,
+    hasActivatedOrdinalsKey,
     showNoticeAlert,
     onDismissRareSatsNotice,
     onLoadMoreRareSatsButtonClick,
@@ -147,6 +147,9 @@ export default function CollectiblesTabs({
     if (tab.key === 'rareSats' && !hasActivatedRareSatsKey) {
       return false;
     }
+    if (tab.key === 'inscriptions' && !hasActivatedOrdinalsKey) {
+      return false;
+    }
     return true;
   };
 
@@ -157,20 +160,22 @@ export default function CollectiblesTabs({
           <StyledTab key={key}>{t(label)}</StyledTab>
         ))}
       </StyledTabList>
-      <TabPanel>
-        {inscriptionsQuery.isLoading ? (
-          <SkeletonLoader isGalleryOpen={isGalleryOpen} />
-        ) : (
-          <>
-            {totalInscriptions > 0 && (
-              <StyledTotalItems typography="body_medium_m" color="white_200">
-                {t('TOTAL_ITEMS', { total: totalInscriptions || 0 })}
-              </StyledTotalItems>
-            )}
-            {inscriptionListView}
-          </>
-        )}
-      </TabPanel>
+      {hasActivatedOrdinalsKey && (
+        <TabPanel>
+          {inscriptionsQuery.isLoading ? (
+            <SkeletonLoader isGalleryOpen={isGalleryOpen} />
+          ) : (
+            <>
+              {totalInscriptions > 0 && (
+                <StyledTotalItems typography="body_medium_m" color="white_200">
+                  {t('TOTAL_ITEMS', { total: totalInscriptions || 0 })}
+                </StyledTotalItems>
+              )}
+              {inscriptionListView}
+            </>
+          )}
+        </TabPanel>
+      )}
       <TabPanel>
         {stacksNftsQuery.isLoading ? (
           <SkeletonLoader isGalleryOpen={isGalleryOpen} />
@@ -185,56 +190,59 @@ export default function CollectiblesTabs({
           </>
         )}
       </TabPanel>
-      <TabPanel>
-        {!rareSatsQuery.isLoading && ordinalBundleCount > 0 && (
-          <StyledTotalItems typography="body_medium_m" color="white_200">
-            {t('TOTAL_ITEMS', { total: ordinalBundleCount })}
-          </StyledTotalItems>
-        )}
+      {hasActivatedRareSatsKey && (
+        <TabPanel>
+          {!rareSatsQuery.isLoading && ordinalBundleCount > 0 && (
+            <StyledTotalItems typography="body_medium_m" color="white_200">
+              {t('TOTAL_ITEMS', { total: ordinalBundleCount })}
+            </StyledTotalItems>
+          )}
 
-        {!rareSatsQuery.isLoading && showNoticeAlert && (
-          <NoticeContainer>
-            <Notice
-              title={t('RARE_SATS_NOTICE_TITLE')}
-              description={t('RARE_SATS_NOTICE_DETAIL')}
-              onClose={() => {
-                onDismissRareSatsNotice();
-              }}
-              seeRarities={() => {
-                navigate('supported-rarity-scale');
-              }}
-            />
-          </NoticeContainer>
-        )}
-        {showNoBundlesNotice && <NoCollectiblesText>{t('NO_COLLECTIBLES')}</NoCollectiblesText>}
+          {!rareSatsQuery.isLoading && showNoticeAlert && (
+            <NoticeContainer>
+              <Notice
+                title={t('RARE_SATS_NOTICE_TITLE')}
+                description={t('RARE_SATS_NOTICE_DETAIL')}
+                onClose={() => {
+                  onDismissRareSatsNotice();
+                }}
+                seeRarities={() => {
+                  navigate('supported-rarity-scale');
+                }}
+              />
+            </NoticeContainer>
+          )}
+          {showNoBundlesNotice && <NoCollectiblesText>{t('NO_COLLECTIBLES')}</NoCollectiblesText>}
 
-        {!!rareSatsQuery.error && <StyledWrenchErrorMessage />}
-        {rareSatsQuery.isLoading ? (
-          <SkeletonLoader isGalleryOpen={isGalleryOpen} />
-        ) : (
-          <GridContainer isGalleryOpen={isGalleryOpen}>
-            {hasActivatedOrdinalsKey &&
-              !rareSatsQuery.error &&
-              !rareSatsQuery.isLoading &&
-              rareSatsQuery.data?.pages
-                ?.map((page) => page?.results)
-                .flat()
-                .map((utxo: ApiBundle) => mapRareSatsAPIResponseToRareSats(utxo))
-                .map((bundle: Bundle) => <RareSatsTabGridItem key={bundle.txid} bundle={bundle} />)}
-          </GridContainer>
-        )}
-        {rareSatsQuery.hasNextPage && (
-          <LoadMoreButtonContainer>
-            <ActionButton
-              transparent
-              text={t('LOAD_MORE')}
-              processing={rareSatsQuery.isFetchingNextPage}
-              disabled={rareSatsQuery.isFetchingNextPage}
-              onPress={onLoadMoreRareSatsButtonClick}
-            />
-          </LoadMoreButtonContainer>
-        )}
-      </TabPanel>
+          {!!rareSatsQuery.error && <StyledWrenchErrorMessage />}
+          {rareSatsQuery.isLoading ? (
+            <SkeletonLoader isGalleryOpen={isGalleryOpen} />
+          ) : (
+            <GridContainer isGalleryOpen={isGalleryOpen}>
+              {!rareSatsQuery.error &&
+                !rareSatsQuery.isLoading &&
+                rareSatsQuery.data?.pages
+                  ?.map((page) => page?.results)
+                  .flat()
+                  .map((utxo: ApiBundle) => mapRareSatsAPIResponseToRareSats(utxo))
+                  .map((bundle: Bundle) => (
+                    <RareSatsTabGridItem key={bundle.txid} bundle={bundle} />
+                  ))}
+            </GridContainer>
+          )}
+          {rareSatsQuery.hasNextPage && (
+            <LoadMoreButtonContainer>
+              <ActionButton
+                transparent
+                text={t('LOAD_MORE')}
+                processing={rareSatsQuery.isFetchingNextPage}
+                disabled={rareSatsQuery.isFetchingNextPage}
+                onPress={onLoadMoreRareSatsButtonClick}
+              />
+            </LoadMoreButtonContainer>
+          )}
+        </TabPanel>
+      )}
     </Tabs>
   );
 }

--- a/src/app/screens/nftDashboard/collectiblesTabs.tsx
+++ b/src/app/screens/nftDashboard/collectiblesTabs.tsx
@@ -40,8 +40,8 @@ const StyledWrenchErrorMessage = styled(WrenchErrorMessage)`
 `;
 
 const NoCollectiblesText = styled.div((props) => ({
-  ...props.theme.body_bold_m,
-  color: props.theme.colors.white['200'],
+  ...props.theme.typography.body_bold_m,
+  color: props.theme.colors.white_200,
   marginTop: props.theme.spacing(16),
   textAlign: 'center',
 }));
@@ -78,10 +78,11 @@ function SkeletonLoader({ isGalleryOpen }: { isGalleryOpen: boolean }) {
   );
 }
 
-const tabs: {
+type TabButton = {
   key: string;
   label: string;
-}[] = [
+};
+const tabs: TabButton[] = [
   {
     key: 'inscriptions',
     label: 'INSCRIPTIONS',
@@ -126,8 +127,8 @@ export default function CollectiblesTabs({
     showNoticeAlert,
     onDismissRareSatsNotice,
     onLoadMoreRareSatsButtonClick,
-    isLoading,
-    isLoadingOrdinalCollections,
+    stacksNftsQuery,
+    inscriptionsQuery,
   } = nftDashboard;
 
   const handleSelectTab = (index: number) => {
@@ -142,17 +143,22 @@ export default function CollectiblesTabs({
   const showNoBundlesNotice =
     ordinalBundleCount === 0 && !rareSatsQuery.isLoading && !rareSatsQuery.error;
 
+  const filterActivatedTabs = (tab: TabButton): boolean => {
+    if (tab.key === 'rareSats' && !hasActivatedRareSatsKey) {
+      return false;
+    }
+    return true;
+  };
+
   return (
     <Tabs className={className} selectedIndex={tabIndex} onSelect={handleSelectTab}>
-      {hasActivatedRareSatsKey && (
-        <StyledTabList>
-          {tabs.map(({ key, label }) => (
-            <StyledTab key={key}>{t(label)}</StyledTab>
-          ))}
-        </StyledTabList>
-      )}
+      <StyledTabList>
+        {tabs.filter(filterActivatedTabs).map(({ key, label }) => (
+          <StyledTab key={key}>{t(label)}</StyledTab>
+        ))}
+      </StyledTabList>
       <TabPanel>
-        {isLoadingOrdinalCollections ? (
+        {inscriptionsQuery.isLoading ? (
           <SkeletonLoader isGalleryOpen={isGalleryOpen} />
         ) : (
           <>
@@ -166,7 +172,7 @@ export default function CollectiblesTabs({
         )}
       </TabPanel>
       <TabPanel>
-        {isLoading ? (
+        {stacksNftsQuery.isLoading ? (
           <SkeletonLoader isGalleryOpen={isGalleryOpen} />
         ) : (
           <>

--- a/src/app/screens/nftDashboard/index.tsx
+++ b/src/app/screens/nftDashboard/index.tsx
@@ -305,7 +305,7 @@ const useNftDashboard = (): NftDashboardState => {
               text={t('LOAD_MORE')}
               processing={stacksNftsQuery.isFetchingNextPage}
               disabled={stacksNftsQuery.isFetchingNextPage}
-              onPress={onClickLoadMoreStacksNfts}
+              onPress={stacksNftsQuery.fetchNextPage}
             />
           </LoadMoreButtonContainer>
         )}

--- a/src/app/screens/nftDashboard/index.tsx
+++ b/src/app/screens/nftDashboard/index.tsx
@@ -148,7 +148,6 @@ export type NftDashboardState = {
   showNoticeAlert?: boolean;
   totalNfts: number;
   totalInscriptions: number;
-  onLoadMoreRareSatsButtonClick: () => void;
 };
 
 const useNftDashboard = (): NftDashboardState => {
@@ -218,10 +217,6 @@ const useNftDashboard = (): NftDashboardState => {
   };
 
   const InscriptionListView = useCallback(() => {
-    const onClickLoadMoreInscriptions = () => {
-      inscriptionsQuery.fetchNextPage();
-    };
-
     if (inscriptionsQuery.error && !(inscriptionsQuery.error instanceof InvalidParamsError)) {
       return (
         <ErrorContainer>
@@ -255,7 +250,7 @@ const useNftDashboard = (): NftDashboardState => {
               text={t('LOAD_MORE')}
               processing={inscriptionsQuery.isFetchingNextPage}
               disabled={inscriptionsQuery.isFetchingNextPage}
-              onPress={onClickLoadMoreInscriptions}
+              onPress={inscriptionsQuery.fetchNextPage}
             />
           </LoadMoreButtonContainer>
         )}
@@ -264,10 +259,6 @@ const useNftDashboard = (): NftDashboardState => {
   }, [inscriptionsQuery, isGalleryOpen, ordinalsLength, t]);
 
   const NftListView = useCallback(() => {
-    const onClickLoadMoreStacksNfts = () => {
-      stacksNftsQuery.fetchNextPage();
-    };
-
     if (stacksNftsQuery.error && !(stacksNftsQuery.error instanceof InvalidParamsError)) {
       return (
         <ErrorContainer>
@@ -334,12 +325,6 @@ const useNftDashboard = (): NftDashboardState => {
     dispatch(SetRareSatsNoticeDismissedAction(true));
   };
 
-  const onLoadMoreRareSatsButtonClick = () => {
-    if (rareSatsQuery?.hasNextPage) {
-      rareSatsQuery.fetchNextPage();
-    }
-  };
-
   return {
     openReceiveModal,
     showNewFeatureAlert,
@@ -364,7 +349,6 @@ const useNftDashboard = (): NftDashboardState => {
     rareSatsQuery,
     totalNfts,
     totalInscriptions: ordinalsLength,
-    onLoadMoreRareSatsButtonClick,
   };
 };
 


### PR DESCRIPTION
# 🔘 PR Type
- [x] Bugfix

# 📜 Background
Issue Link: https://linear.app/xverseapp/issue/ENG-3107/disabling-ordinals-user-should-not-see-them-in-the-collectibles-ui 

# 🔄 Changes
- fix: load more button on inscriptions now only loads more inscriptions
- fix: disabling/enabling ordinals hides/shows the inscriptions tab and tab button
- fix: disabling/enabling rare sats hides/shows the rare sats tab and tab button

Impact:
- refactored nftDashboard/index.tsx to further separate fetching logic between tabs
- decoupled the useEffect of a stacks address change from an ordinals address change

# 🖼 Screenshot / 📹 Video

https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/38bd6b4d-a913-4a76-b153-e81580783856



# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
