### PR TITLE
fix: inscriptions and 1 step BRC-20 and seed vault (ENG-3125)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ledgerhq/hw-transport-webusb": "^6.27.13",
         "@phosphor-icons/react": "^2.0.10",
         "@react-spring/web": "^9.6.1",
-        "@secretkeylabs/xverse-core": "2.1.0-ec3333d",
+        "@secretkeylabs/xverse-core": "^2.1.0-efb112e",
         "@stacks/connect": "^6.10.2",
         "@stacks/encryption": "4.3.5",
         "@stacks/stacks-blockchain-api-types": "6.1.1",
@@ -2213,9 +2213,9 @@
       }
     },
     "node_modules/@secretkeylabs/xverse-core": {
-      "version": "2.1.0-ec3333d",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/2.1.0-ec3333d/80f341a4b092fa31493e0086b8073f829d078ac0",
-      "integrity": "sha512-e3lXGlL7ujDn59X76i13I+qAZcuHEpiEvCqSpUvSQgnU2p8L5nvNMmus8KgLOl7DKg+Aivn/paolMevqvI64eg==",
+      "version": "2.1.0-efb112e",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/2.1.0-efb112e/437e108ae9e3322b9350b4f9f986b32638be5cdf",
+      "integrity": "sha512-HdMrJ2pFdmXlcqpSEnbO++4hk0Dtvy9bSHf17n93f0tUqlNp86IgJ5mlccmrBTSSf+nWp4ZnlLCiknu+0IyWMQ==",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
@@ -20458,9 +20458,9 @@
       }
     },
     "@secretkeylabs/xverse-core": {
-      "version": "2.1.0-ec3333d",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/2.1.0-ec3333d/80f341a4b092fa31493e0086b8073f829d078ac0",
-      "integrity": "sha512-e3lXGlL7ujDn59X76i13I+qAZcuHEpiEvCqSpUvSQgnU2p8L5nvNMmus8KgLOl7DKg+Aivn/paolMevqvI64eg==",
+      "version": "2.1.0-efb112e",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/2.1.0-efb112e/437e108ae9e3322b9350b4f9f986b32638be5cdf",
+      "integrity": "sha512-HdMrJ2pFdmXlcqpSEnbO++4hk0Dtvy9bSHf17n93f0tUqlNp86IgJ5mlccmrBTSSf+nWp4ZnlLCiknu+0IyWMQ==",
       "requires": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
         "@noble/secp256k1": "^1.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ledgerhq/hw-transport-webusb": "^6.27.13",
         "@phosphor-icons/react": "^2.0.10",
         "@react-spring/web": "^9.6.1",
-        "@secretkeylabs/xverse-core": "^2.1.0-efb112e",
+        "@secretkeylabs/xverse-core": "2.2.0",
         "@stacks/connect": "^6.10.2",
         "@stacks/encryption": "4.3.5",
         "@stacks/stacks-blockchain-api-types": "6.1.1",
@@ -2213,9 +2213,9 @@
       }
     },
     "node_modules/@secretkeylabs/xverse-core": {
-      "version": "2.1.0-efb112e",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/2.1.0-efb112e/437e108ae9e3322b9350b4f9f986b32638be5cdf",
-      "integrity": "sha512-HdMrJ2pFdmXlcqpSEnbO++4hk0Dtvy9bSHf17n93f0tUqlNp86IgJ5mlccmrBTSSf+nWp4ZnlLCiknu+0IyWMQ==",
+      "version": "2.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/2.2.0/1fa5556b7a02d9c6f924a580d7047e8f48c820f1",
+      "integrity": "sha512-dojD+kCuPvcowExpotozJWYuYqvQ9KMIoZx/PGgEa6xRSvh8tPcAmkoKTsrVRAVrKp0hgQ/VXW8yuOTeFPxk3Q==",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
@@ -20458,9 +20458,9 @@
       }
     },
     "@secretkeylabs/xverse-core": {
-      "version": "2.1.0-efb112e",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/2.1.0-efb112e/437e108ae9e3322b9350b4f9f986b32638be5cdf",
-      "integrity": "sha512-HdMrJ2pFdmXlcqpSEnbO++4hk0Dtvy9bSHf17n93f0tUqlNp86IgJ5mlccmrBTSSf+nWp4ZnlLCiknu+0IyWMQ==",
+      "version": "2.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/2.2.0/1fa5556b7a02d9c6f924a580d7047e8f48c820f1",
+      "integrity": "sha512-dojD+kCuPvcowExpotozJWYuYqvQ9KMIoZx/PGgEa6xRSvh8tPcAmkoKTsrVRAVrKp0hgQ/VXW8yuOTeFPxk3Q==",
       "requires": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
         "@noble/secp256k1": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@ledgerhq/hw-transport-webusb": "^6.27.13",
     "@phosphor-icons/react": "^2.0.10",
     "@react-spring/web": "^9.6.1",
-    "@secretkeylabs/xverse-core": "2.1.0-ec3333d",
+    "@secretkeylabs/xverse-core": "^2.1.0-efb112e",
     "@stacks/connect": "^6.10.2",
     "@stacks/encryption": "4.3.5",
     "@stacks/stacks-blockchain-api-types": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@ledgerhq/hw-transport-webusb": "^6.27.13",
     "@phosphor-icons/react": "^2.0.10",
     "@react-spring/web": "^9.6.1",
-    "@secretkeylabs/xverse-core": "^2.1.0-efb112e",
+    "@secretkeylabs/xverse-core": "2.2.0",
     "@stacks/connect": "^6.10.2",
     "@stacks/encryption": "4.3.5",
     "@stacks/stacks-blockchain-api-types": "6.1.1",

--- a/src/app/screens/createInscription/index.tsx
+++ b/src/app/screens/createInscription/index.tsx
@@ -27,6 +27,7 @@ import useWalletSelector from '@hooks/useWalletSelector';
 import type { UTXO } from '@secretkeylabs/xverse-core/types';
 import { getShortTruncatedAddress } from '@utils/helper';
 
+import useSeedVault from '@hooks/useSeedVault';
 import CompleteScreen from './CompleteScreen';
 import ContentLabel from './ContentLabel';
 import EditFee from './EditFee';
@@ -179,16 +180,10 @@ function CreateInscription() {
   const [showFeeSettings, setShowFeeSettings] = useState(false);
   const [feeRate, setFeeRate] = useState(suggestedMinerFeeRate ?? DEFAULT_FEE_RATE);
   const [feeRates, setFeeRates] = useState<BtcFeeResponse>();
+  const { getSeed } = useSeedVault();
 
-  const {
-    ordinalsAddress,
-    network,
-    btcAddress,
-    seedPhrase,
-    selectedAccount,
-    btcFiatRate,
-    fiatCurrency,
-  } = useWalletSelector();
+  const { ordinalsAddress, network, btcAddress, selectedAccount, btcFiatRate, fiatCurrency } =
+    useWalletSelector();
 
   useEffect(() => {
     getNonOrdinalUtxo(btcAddress, requestedNetwork.type).then(setUtxos);
@@ -255,7 +250,7 @@ function CreateInscription() {
     feeRate,
     network: requestedNetwork.type,
     revealAddress: ordinalsAddress,
-    seedPhrase,
+    getSeedPhrase: getSeed,
     contentBase64: payloadType === 'BASE_64' ? content : undefined,
     contentString: payloadType === 'PLAIN_TEXT' ? content : undefined,
     serviceFee: appFee,

--- a/src/app/screens/executeBrc20Transaction/index.tsx
+++ b/src/app/screens/executeBrc20Transaction/index.tsx
@@ -1,26 +1,28 @@
-import useWalletSelector from '@hooks/useWalletSelector';
-import { ExecuteBrc20TransferState } from '@utils/brc20';
-import { ExecuteTransferProgressCodes, useBrc20TransferExecute } from '@secretkeylabs/xverse-core';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { getBtcTxStatusUrl } from '@utils/helper';
-import { ConfirmationStatus } from '@components/loadingTransactionStatus/circularSvgAnimation';
-import { useState, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
 import { LoadingTransactionStatus } from '@components/loadingTransactionStatus';
+import { ConfirmationStatus } from '@components/loadingTransactionStatus/circularSvgAnimation';
+import useSeedVault from '@hooks/useSeedVault';
+import useWalletSelector from '@hooks/useWalletSelector';
+import { ExecuteTransferProgressCodes, useBrc20TransferExecute } from '@secretkeylabs/xverse-core';
+import { ExecuteBrc20TransferState } from '@utils/brc20';
+import { getBtcTxStatusUrl } from '@utils/helper';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 const AMOUNT_OF_STEPS = Object.keys(ExecuteTransferProgressCodes).length + 1;
 const PERCENTAGE_PER_STEP = 1 / AMOUNT_OF_STEPS;
 
 export function ExecuteBrc20Transaction() {
   const { t } = useTranslation('translation', { keyPrefix: 'EXECUTE_BRC20' });
-  const { selectedAccount, btcAddress, network, seedPhrase } = useWalletSelector();
+  const { selectedAccount, btcAddress, network } = useWalletSelector();
   const navigate = useNavigate();
   const { recipientAddress, estimateFeesParams }: ExecuteBrc20TransferState = useLocation().state;
+  const { getSeed } = useSeedVault();
 
   const { progress, complete, executeTransfer, transferTransactionId, errorCode } =
     useBrc20TransferExecute({
       ...estimateFeesParams,
-      seedPhrase,
+      getSeedPhrase: getSeed,
       accountIndex: selectedAccount?.id ?? 0,
       changeAddress: btcAddress,
       recipientAddress,


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background
When we merged in the seed vault, the Inscription and 1 step BRC-20 pages were not updated with the new typing.

This updates the Core version to that with the correct types and implements the type changes.

# 🔄 Changes
The Inscription confirmation and 1 step-BRC-20 pages both now pass through the getSeed method from the seed vault instead of the seed phrase. This was tested by making an inscription in Testnet.

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
