### PR TITLE
fix: only display tab buttons when more than one tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "*.{ts,tsx}": [
       "prettier --write",
       "eslint",
-      "tsc-files --noEmit"
+      "tsc-files --noEmit src/styled.d.ts src/react-app-env.d.ts"
     ],
     "*.json": [
       "prettier --write"

--- a/src/app/screens/nftDashboard/collectiblesTabs.tsx
+++ b/src/app/screens/nftDashboard/collectiblesTabs.tsx
@@ -142,7 +142,7 @@ export default function CollectiblesTabs({
   const showNoBundlesNotice =
     ordinalBundleCount === 0 && !rareSatsQuery.isLoading && !rareSatsQuery.error;
 
-  const filterActivatedTabs = (tab: TabButton): boolean => {
+  const visibleTabButtons = tabs.filter((tab: TabButton) => {
     if (tab.key === 'rareSats' && !hasActivatedRareSatsKey) {
       return false;
     }
@@ -150,15 +150,17 @@ export default function CollectiblesTabs({
       return false;
     }
     return true;
-  };
+  });
 
   return (
     <Tabs className={className} selectedIndex={tabIndex} onSelect={handleSelectTab}>
-      <StyledTabList>
-        {tabs.filter(filterActivatedTabs).map(({ key, label }) => (
-          <StyledTab key={key}>{t(label)}</StyledTab>
-        ))}
-      </StyledTabList>
+      {visibleTabButtons.length > 1 && (
+        <StyledTabList>
+          {visibleTabButtons.map(({ key, label }) => (
+            <StyledTab key={key}>{t(label)}</StyledTab>
+          ))}
+        </StyledTabList>
+      )}
       {hasActivatedOrdinalsKey && (
         <TabPanel>
           {inscriptionsQuery.isLoading ? (


### PR DESCRIPTION
# 🔘 PR Type
- [x] Bugfix

# 📜 Background
Provide a brief explanation of why this pull request is needed. Include the problem you are solving or the functionality you are adding. Reference any related issues.

Issue Link: #[issue_number]
Context Link (if applicable):

# 🔄 Changes
- fix: add logic to not display tab buttons when only one tab should show
- chore: fix up the precommit tsc-files check not parsing the custom theme type

# 🖼 Screenshot / 📹 Video
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/c7f7fc23-fa80-43b6-b1c1-1ee029c3c61a)

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
