### PR TITLE
fix: collectibles UI bugs

### DIFF
--- a/src/app/components/confirmBtcTransactionComponent/index.tsx
+++ b/src/app/components/confirmBtcTransactionComponent/index.tsx
@@ -15,9 +15,9 @@ import {
   getBtcFiatEquivalent,
   ResponseError,
   satsToBtc,
+  signBtcTransaction,
   UTXO,
 } from '@secretkeylabs/xverse-core';
-import { signBtcTransaction } from '@secretkeylabs/xverse-core/transactions';
 import {
   Recipient,
   SignedBtcTx,
@@ -82,7 +82,7 @@ const Button = styled.button((props) => ({
 }));
 
 const ButtonText = styled.div((props) => ({
-  ...props.theme.body_medium_m,
+  ...props.theme.typography.body_medium_m,
   color: props.theme.colors.white_0,
   textAlign: 'center',
 }));
@@ -100,15 +100,15 @@ const ErrorContainer = styled.div((props) => ({
 }));
 
 const ErrorText = styled.h1((props) => ({
-  ...props.theme.body_xs,
-  color: props.theme.colors.feedback.error,
+  ...props.theme.typography.body_s,
+  color: props.theme.colors.danger_medium,
 }));
 
 interface ReviewTransactionTitleProps {
   isOridnalTx: boolean;
 }
 const ReviewTransactionText = styled.h1<ReviewTransactionTitleProps>((props) => ({
-  ...props.theme.headline_s,
+  ...props.theme.typography.headline_s,
   color: props.theme.colors.white_0,
   marginBottom: props.theme.spacing(16),
   textAlign: props.isOridnalTx ? 'center' : 'left',
@@ -318,7 +318,7 @@ function ConfirmBtcTransactionComponent({
     const newFee = new BigNumber(modifiedFee);
     setCurrentFee(newFee);
     const seed = await getSeed();
-    setCurrentFeeRate(new BigNumber(feeRate));
+    setCurrentFeeRate(new BigNumber(feeRate ?? ''));
     if (ordinalTxUtxo) ordinalMutate({ txFee: modifiedFee, seedPhrase: seed });
     else if (isRestoreFundFlow) {
       mutateSignNonOrdinalBtcTransaction({ txFee: modifiedFee, seedPhrase: seed });
@@ -414,6 +414,7 @@ function ConfirmBtcTransactionComponent({
           ) : (
             recipients?.map((recipient, index) => (
               <RecipientComponent
+                key={recipient.address}
                 recipientIndex={index + 1}
                 address={recipient.address}
                 value={satsToBtc(recipient.amountSats).toString()}

--- a/src/app/screens/confirmOrdinalTransaction/index.tsx
+++ b/src/app/screens/confirmOrdinalTransaction/index.tsx
@@ -78,8 +78,8 @@ function ConfirmOrdinalTransaction() {
   const [currentFee, setCurrentFee] = useState(fee);
   const [currentFeeRate, setCurrentFeeRate] = useState(feePerVByte);
 
-  const bundleId = selectedSatBundle ? getBundleId(selectedSatBundle) : '';
-  const bundleSubText = selectedSatBundle ? getBundleSubText(selectedSatBundle) : '';
+  const bundleId = isRareSat && selectedSatBundle ? getBundleId(selectedSatBundle) : '';
+  const bundleSubText = isRareSat && selectedSatBundle ? getBundleSubText(selectedSatBundle) : '';
 
   const {
     isLoading,

--- a/src/app/screens/nftDashboard/index.tsx
+++ b/src/app/screens/nftDashboard/index.tsx
@@ -169,11 +169,15 @@ const useNftDashboard = (): NftDashboardState => {
   const rareSatsQuery = useAddressRareSats();
 
   useEffect(() => {
-    stacksNftsQuery.refetch();
+    if (stxAddress && !stacksNftsQuery.error) {
+      stacksNftsQuery.refetch();
+    }
   }, [stxAddress, stacksNftsQuery]);
 
   useEffect(() => {
-    inscriptionsQuery.refetch();
+    if (ordinalsAddress && !inscriptionsQuery.error) {
+      inscriptionsQuery.refetch();
+    }
   }, [ordinalsAddress, inscriptionsQuery]);
 
   const ordinalsLength = inscriptionsQuery.data?.pages?.[0]?.total ?? 0;

--- a/src/app/screens/nftDashboard/index.tsx
+++ b/src/app/screens/nftDashboard/index.tsx
@@ -154,8 +154,6 @@ const useNftDashboard = (): NftDashboardState => {
   const { t } = useTranslation('translation', { keyPrefix: 'NFT_DASHBOARD_SCREEN' });
   const dispatch = useDispatch();
   const {
-    stxAddress,
-    ordinalsAddress,
     hasActivatedOrdinalsKey,
     hasActivatedRareSatsKey,
     rareSatsNoticeDismissed,
@@ -167,18 +165,6 @@ const useNftDashboard = (): NftDashboardState => {
   const stacksNftsQuery = useStacksCollectibles();
   const inscriptionsQuery = useAddressInscriptionCollections();
   const rareSatsQuery = useAddressRareSats();
-
-  useEffect(() => {
-    if (stxAddress && !stacksNftsQuery.error) {
-      stacksNftsQuery.refetch();
-    }
-  }, [stxAddress, stacksNftsQuery]);
-
-  useEffect(() => {
-    if (ordinalsAddress && !inscriptionsQuery.error) {
-      inscriptionsQuery.refetch();
-    }
-  }, [ordinalsAddress, inscriptionsQuery]);
 
   const ordinalsLength = inscriptionsQuery.data?.pages?.[0]?.total ?? 0;
   const totalNfts = stacksNftsQuery.data?.pages?.[0]?.total ?? 0;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -488,7 +488,7 @@ const Theme = {
   },
 
   /**
-   * @deprecated use theme.typography
+   * @deprecated use theme.typography.body_s
    */
   body_xs: {
     fontFamily: 'DMSans-Regular',


### PR DESCRIPTION
# 🔘 PR Type
- [x] Bugfix

# 📜 Background
- https://linear.app/xverseapp/issue/ENG-3132/missing-tooltip-copied-after-clicking-receive-button-for-ledger
- https://linear.app/xverseapp/issue/ENG-3136/not-displaying-rarity-type-for-ordinals-and-the-id

# 🔄 Changes
- fix: a bug with ledger device refetching, when no stx address (was the cause of the missing tooltip bug)
- fix: confirm ordinal tx screen - do not display rarity type and id when unless sending a rare sat

impact:
- removed the refetch useEffects reacting to stxAddress or ordinalsAddress change. tested account switching scenarios without these, including with a gallery view open, and on ledger device. concluded they were unnecessary

# 🖼 Screenshot / 📹 Video
copied toolip from ledger without STX address:
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/d58aa141-df10-4e6f-b823-26d7ae3b63a4)

send ordinal from gallery view ledger:
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/8fb64764-f09d-481c-bb25-fd74a485cd38)

send ordinal from extension:
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/7364c9b8-7a44-4fe0-93dd-5c5768ac4720)

send rare sat from extension:
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/ba1e93dc-4f64-441a-bac2-4cd0bad311a2)

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
