### PR TITLE
hotfix: react query cache settings

### DIFF
--- a/src/app/hooks/queries/ordinals/useAddressInscriptionCollections.ts
+++ b/src/app/hooks/queries/ordinals/useAddressInscriptionCollections.ts
@@ -31,8 +31,7 @@ const useAddressInscriptionCollections = () => {
       }
       return false;
     },
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
+    staleTime: 1 * 60 * 1000, // 1 min
   });
 };
 

--- a/src/app/hooks/queries/ordinals/useAddressInscriptions.ts
+++ b/src/app/hooks/queries/ordinals/useAddressInscriptions.ts
@@ -40,8 +40,7 @@ const useAddressInscriptions = (collectionId?: string) => {
         }
         return false;
       },
-      refetchOnMount: false,
-      refetchOnWindowFocus: false,
+      staleTime: 1 * 60 * 1000, // 1 min
     },
   );
 };

--- a/src/app/hooks/queries/ordinals/useAddressRareSats.ts
+++ b/src/app/hooks/queries/ordinals/useAddressRareSats.ts
@@ -28,8 +28,6 @@ export const useAddressRareSats = () => {
   };
 
   return useInfiniteQuery(['rare-sats', ordinalsAddress], getRareSatsByAddress, {
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
     retry: handleRetries,
     getNextPageParam: (lastPage, allPages) => {
       const currentLength = allPages.map((page) => page.results).flat().length;
@@ -37,6 +35,7 @@ export const useAddressRareSats = () => {
         return currentLength;
       }
     },
+    staleTime: 1 * 60 * 1000, // 1 min
   });
 };
 
@@ -54,11 +53,10 @@ export const useGetUtxoOrdinalBundle = (output?: string, shouldMakeTheCall?: boo
 
   const { data, isLoading } = useQuery({
     enabled: !!(output && shouldMakeTheCall),
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
     queryKey: ['rare-sats', output],
     queryFn: getUtxoOrdinalBundleByOutput,
     retry: handleRetries,
+    staleTime: 1 * 60 * 1000, // 1 min
   });
   const bundle = data?.txid ? mapRareSatsAPIResponseToRareSats(data) : undefined;
 

--- a/src/app/hooks/queries/ordinals/useCollectionMarketData.ts
+++ b/src/app/hooks/queries/ordinals/useCollectionMarketData.ts
@@ -20,6 +20,7 @@ const useInscriptionCollectionMarketData = (collectionId?: string | null) => {
     retry: handleRetries,
     queryKey: ['collection-market-data', collectionId],
     queryFn: collectionMarketData,
+    staleTime: 1 * 60 * 1000, // 1 min
   });
 };
 

--- a/src/app/hooks/queries/useAppConfig.ts
+++ b/src/app/hooks/queries/useAppConfig.ts
@@ -1,5 +1,5 @@
 import useWalletSelector from '@hooks/useWalletSelector';
-import { getAppConfig } from '@secretkeylabs/xverse-core/api/xverse';
+import { getAppConfig } from '@secretkeylabs/xverse-core';
 import { ChangeNetworkAction } from '@stores/wallet/actions/actionCreators';
 import { useQuery } from '@tanstack/react-query';
 import { useDispatch } from 'react-redux';

--- a/src/app/hooks/queries/useBtcWalletData.ts
+++ b/src/app/hooks/queries/useBtcWalletData.ts
@@ -19,10 +19,10 @@ export const useBtcWalletData = () => {
   };
 
   return useQuery({
-    queryKey: [`wallet-data-${btcAddress}`],
-    refetchOnWindowFocus: true,
+    queryKey: ['btc-wallet-data', btcAddress],
     queryFn: fetchBtcWalletData,
     enabled: !!btcAddress,
+    staleTime: 10 * 1000, // 10 secs
   });
 };
 

--- a/src/app/hooks/queries/useCoinRates.ts
+++ b/src/app/hooks/queries/useCoinRates.ts
@@ -1,5 +1,5 @@
 import useWalletSelector from '@hooks/useWalletSelector';
-import { fetchBtcToCurrencyRate, fetchStxToBtcRate } from '@secretkeylabs/xverse-core/api';
+import { fetchBtcToCurrencyRate, fetchStxToBtcRate } from '@secretkeylabs/xverse-core';
 import { setCoinRatesAction } from '@stores/wallet/actions/actionCreators';
 import { useQuery } from '@tanstack/react-query';
 import { useDispatch } from 'react-redux';
@@ -24,6 +24,7 @@ export const useCoinRates = () => {
   return useQuery({
     queryKey: ['coin_rates'],
     queryFn: fetchCoinRates,
+    staleTime: 5 * 60 * 1000, // 5 min
   });
 };
 

--- a/src/app/hooks/queries/useFeeMultipliers.ts
+++ b/src/app/hooks/queries/useFeeMultipliers.ts
@@ -1,6 +1,6 @@
 import useWalletSelector from '@hooks/useWalletSelector';
-import { fetchAppInfo } from '@secretkeylabs/xverse-core/api';
-import { AppInfo } from '@secretkeylabs/xverse-core/types';
+import type { AppInfo } from '@secretkeylabs/xverse-core';
+import { fetchAppInfo } from '@secretkeylabs/xverse-core';
 import { setFeeMultiplierAction } from '@stores/wallet/actions/actionCreators';
 import { useQuery } from '@tanstack/react-query';
 import { useDispatch } from 'react-redux';

--- a/src/app/hooks/queries/useStxPendingTxData.ts
+++ b/src/app/hooks/queries/useStxPendingTxData.ts
@@ -1,7 +1,7 @@
+import { fetchStxPendingTxData } from '@secretkeylabs/xverse-core';
+import { StoreState } from '@stores/index';
 import { useQuery } from '@tanstack/react-query';
 import { useSelector } from 'react-redux';
-import { fetchStxPendingTxData } from '@secretkeylabs/xverse-core/api';
-import { StoreState } from '@stores/index';
 import useNetworkSelector from '../useNetwork';
 
 const useStxPendingTxData = () => {

--- a/src/app/hooks/queries/useStxWalletData.ts
+++ b/src/app/hooks/queries/useStxWalletData.ts
@@ -1,5 +1,5 @@
-import { fetchStxAddressData } from '@secretkeylabs/xverse-core/api';
-import { StxAddressData } from '@secretkeylabs/xverse-core/types';
+import type { StxAddressData } from '@secretkeylabs/xverse-core';
+import { fetchStxAddressData } from '@secretkeylabs/xverse-core';
 import { setStxWalletDataAction } from '@stores/wallet/actions/actionCreators';
 import { useQuery } from '@tanstack/react-query';
 import { PAGINATION_LIMIT } from '@utils/constants';
@@ -32,9 +32,10 @@ export const useStxWalletData = () => {
   };
 
   return useQuery({
-    queryKey: [`wallet-data-${stxAddress}`],
+    queryKey: ['stx-wallet-data', stxAddress],
     queryFn: fetchStxWalletData,
     enabled: !!stxAddress,
+    staleTime: 10 * 1000, // 10 secs
   });
 };
 

--- a/src/app/hooks/queries/useTransactions.ts
+++ b/src/app/hooks/queries/useTransactions.ts
@@ -1,6 +1,6 @@
 import useWalletSelector from '@hooks/useWalletSelector';
-import { fetchBtcTransactionsData, getBrc20History } from '@secretkeylabs/xverse-core/api';
-import { Brc20HistoryTransactionData, BtcTransactionData } from '@secretkeylabs/xverse-core/types';
+import type { Brc20HistoryTransactionData, BtcTransactionData } from '@secretkeylabs/xverse-core';
+import { fetchBtcTransactionsData, getBrc20History } from '@secretkeylabs/xverse-core';
 import {
   AddressTransactionWithTransfers,
   MempoolTransaction,

--- a/src/app/hooks/useTextOrdinalContent.ts
+++ b/src/app/hooks/useTextOrdinalContent.ts
@@ -1,5 +1,5 @@
-import { getTextOrdinalContent } from '@secretkeylabs/xverse-core/api/index';
-import type { CondensedInscription, Inscription } from '@secretkeylabs/xverse-core/types';
+import type { CondensedInscription, Inscription } from '@secretkeylabs/xverse-core';
+import { getTextOrdinalContent } from '@secretkeylabs/xverse-core';
 import { useQuery } from '@tanstack/react-query';
 import PQueue from 'p-queue';
 import useWalletSelector from './useWalletSelector';
@@ -11,8 +11,7 @@ const useTextOrdinalContent = (ordinal: Inscription | CondensedInscription) => {
   const { data: textContent } = useQuery({
     queryKey: [`ordinal-text-${ordinal?.id}`],
     queryFn: async () => queue.add(() => getTextOrdinalContent(network.type, ordinal?.id)),
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
+    staleTime: 5 * 60 * 1000, // 5 min
   });
 
   return textContent?.toString();

--- a/src/app/hooks/useWalletReducer.ts
+++ b/src/app/hooks/useWalletReducer.ts
@@ -254,7 +254,7 @@ const useWalletReducer = () => {
   const switchAccount = async (account: Account) => {
     // we clear the query cache to prevent data from the other account potentially being displayed
     await queryClient.cancelQueries();
-    await queryClient.clear();
+    queryClient.clear();
 
     dispatch(
       selectAccount(

--- a/src/app/utils/query.ts
+++ b/src/app/utils/query.ts
@@ -15,6 +15,23 @@ export function handleRetries(failureCount: number, error: unknown): boolean {
   return failureCount < 3;
 }
 
-export const queryClient = new QueryClient();
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // time before garbage collection of query data
+      cacheTime: 5 * 60 * 1000, // 5 min
+
+      // increase this for specific queries to reduce refetches
+      staleTime: 0,
+
+      // at least one of these are required to refetch stale queries
+      // refetchInterval
+      // refetchIntervalInBackground
+      refetchOnMount: true,
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
+    },
+  },
+});
 
 export const offlineStorage = createSyncStoragePersister({ storage: window.localStorage });


### PR DESCRIPTION
# 🔘 PR Type
- [x] Bugfix

# 📜 Background
Issue Link: https://linear.app/xverseapp/issue/ENG-3057/investigate-inscriptions-and-rare-sats-query-cache-and-global-query

# 🔄 Changes
- set explicit global react-query cache defaults
- prefer use of `staleTime` instead of `refetchXXX: false`, to reduce number of fetches

Impact:
- queries where previously refetches were disabled, and now are enabled:
/src/app/hooks/queries/ordinals/useAddressInscriptionCollections.ts
/src/app/hooks/queries/ordinals/useAddressInscriptions.ts
/src/app/hooks/queries/ordinals/useAddressRareSats.ts
/src/app/hooks/useTextOrdinalContent.ts

- queries where previously would refetch on every mount and window focus, but have added some staleTime to reduce refetches:
/src/app/hooks/queries/ordinals/useCollectionMarketData.ts
/src/app/hooks/queries/useBtcWalletData.ts
/src/app/hooks/queries/useCoinRates.ts
/src/app/hooks/queries/useStxWalletData.ts

# 🖼 Screenshot / 📹 Video
showing the new behaviour when receiving a new inscription, refetch should be triggered either when focusing back on the window (refetchOnWindowFocus), or clicking between tabs (refetchOnMount):

https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/aa763de4-52b0-4f46-b073-5ad323916e9c


showing the new behaviour which reduces the number of network requests when focusing back on the window:

https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/e418d2c4-0988-46d7-b0b3-4fb74b294a2c

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
