### PR TITLE
fix: show snackbar if NFT metadata is failed to fetch

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,16 +2,16 @@ import LoadingScreen from '@components/loadingScreen';
 import rootStore from '@stores/index';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { MIX_PANEL_TOKEN } from '@utils/constants';
 import { queryClient } from '@utils/query';
+import mixpanel from 'mixpanel-browser';
+import { useEffect } from 'react';
 import { Toaster } from 'react-hot-toast';
 import { Provider } from 'react-redux';
 import { RouterProvider } from 'react-router-dom';
 import { PersistGate } from 'redux-persist/integration/react';
 import { ThemeProvider } from 'styled-components';
 import '../locales';
-import { useEffect } from 'react';
-import mixpanel from 'mixpanel-browser';
-import { MIX_PANEL_TOKEN } from '@utils/constants';
 import Theme from '../theme';
 import GlobalStyle from '../theme/global';
 import SessionGuard from './components/guards/session';
@@ -40,7 +40,7 @@ function App(): JSX.Element {
             <SessionGuard>
               <ThemeProvider theme={Theme}>
                 <RouterProvider router={router} />
-                <Toaster position="bottom-center" containerStyle={{ bottom: 80 }} />
+                <Toaster position="bottom-center" />
               </ThemeProvider>
             </SessionGuard>
           </PersistGate>

--- a/src/app/screens/nftCollection/index.tsx
+++ b/src/app/screens/nftCollection/index.tsx
@@ -188,14 +188,19 @@ function NftCollection() {
                   key={nft.asset_identifier}
                   item={nft}
                   itemId={getNftCollectionsGridItemId(nft, collectionData)}
-                  onClick={() => {
-                    if (isBnsCollection(nft.asset_identifier)) return;
-                    if (nft.data?.token_metadata) {
-                      navigate(`/nft-dashboard/nft-detail/${nft.data?.fully_qualified_token_id}`);
-                    } else {
-                      toast.custom(ToastContent);
-                    }
-                  }}
+                  onClick={
+                    isBnsCollection(nft.asset_identifier)
+                      ? undefined
+                      : () => {
+                          if (nft.data?.token_metadata) {
+                            navigate(
+                              `/nft-dashboard/nft-detail/${nft.data?.fully_qualified_token_id}`,
+                            );
+                          } else {
+                            toast.custom(ToastContent);
+                          }
+                        }
+                  }
                 >
                   <Nft asset={nft} isGalleryOpen={isGalleryOpen} />
                 </CollectibleCollectionGridItem>

--- a/src/app/screens/nftCollection/index.tsx
+++ b/src/app/screens/nftCollection/index.tsx
@@ -9,8 +9,11 @@ import WrenchErrorMessage from '@components/wrenchErrorMessage';
 import { ArrowLeft } from '@phosphor-icons/react';
 import { GridContainer } from '@screens/nftDashboard/collectiblesTabs';
 import Nft from '@screens/nftDashboard/nft';
-import { getNftCollectionsGridItemId } from '@utils/nfts';
+import SnackBar from '@ui-library/snackBar';
+import { getNftCollectionsGridItemId, isBnsCollection } from '@utils/nfts';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import useNftCollection from './useNftCollection';
 
@@ -109,6 +112,7 @@ const StyledGridContainer = styled(GridContainer)`
 
 function NftCollection() {
   const { t } = useTranslation('translation', { keyPrefix: 'COLLECTIBLE_COLLECTION_SCREEN' });
+  const navigate = useNavigate();
   const {
     collectionData,
     portfolioValue,
@@ -118,8 +122,9 @@ function NftCollection() {
     isGalleryOpen,
     handleBackButtonClick,
     openInGalleryView,
-    handleOnClick,
   } = useNftCollection();
+
+  const ToastContent = <SnackBar text={t('ERRORS.FAILED_TO_FETCH')} type="error" />;
 
   return (
     <>
@@ -183,7 +188,14 @@ function NftCollection() {
                   key={nft.asset_identifier}
                   item={nft}
                   itemId={getNftCollectionsGridItemId(nft, collectionData)}
-                  onClick={handleOnClick}
+                  onClick={() => {
+                    if (isBnsCollection(nft.asset_identifier)) return;
+                    if (nft.data?.token_metadata) {
+                      navigate(`/nft-dashboard/nft-detail/${nft.data?.fully_qualified_token_id}`);
+                    } else {
+                      toast.custom(ToastContent);
+                    }
+                  }}
                 >
                   <Nft asset={nft} isGalleryOpen={isGalleryOpen} />
                 </CollectibleCollectionGridItem>

--- a/src/app/screens/nftCollection/useNftCollection.ts
+++ b/src/app/screens/nftCollection/useNftCollection.ts
@@ -1,7 +1,5 @@
 import useStacksCollectibles from '@hooks/queries/useStacksCollectibles';
 import useResetUserFlow from '@hooks/useResetUserFlow';
-import { NonFungibleToken } from '@secretkeylabs/xverse-core';
-import { isBnsCollection } from '@utils/nfts';
 import { useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -33,12 +31,6 @@ export default function useNftCollection() {
     });
   };
 
-  const handleOnClick = isBnsCollection(collectionData?.collection_id)
-    ? undefined
-    : (nft: NonFungibleToken) => {
-        navigate(`/nft-dashboard/nft-detail/${nft.data?.fully_qualified_token_id}`);
-      };
-
   return {
     collectionData,
     portfolioValue,
@@ -48,6 +40,5 @@ export default function useNftCollection() {
     isGalleryOpen,
     handleBackButtonClick,
     openInGalleryView,
-    handleOnClick,
   };
 }

--- a/src/app/ui-library/snackBar.tsx
+++ b/src/app/ui-library/snackBar.tsx
@@ -1,0 +1,72 @@
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+
+type ToastType = 'success' | 'error' | 'neutral';
+
+interface ToastProps {
+  text: string;
+  type: ToastType;
+}
+
+const getBackgroundColor = (type: ToastType, theme: any): string => {
+  const colors = {
+    success: theme.colors.feedback.success,
+    error: theme.colors.feedback.error,
+    neutral: theme.colors.feedback.neutral,
+  };
+  return colors[type] || theme.colors.feedback.neutral;
+};
+
+const getTextColor = (type: ToastType, theme: any): string => {
+  const colors = {
+    success: theme.colors.elevation0,
+    error: theme.colors.white_0,
+    neutral: theme.colors.white_0,
+  };
+  return colors[type] || theme.colors.elevation0;
+};
+
+const ToastContainer = styled.div<{ type: ToastType }>`
+  display: flex;
+  flex-direction: row;
+  background: ${(props) => getBackgroundColor(props.type, props.theme)};
+  border-radius: 12px;
+  box-shadow: 0px 7px 16px -4px rgba(25, 25, 48, 0.25);
+  height: 44px;
+  padding: 12px 20px;
+  width: 306px;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const ToastMessage = styled.h1<{ type: ToastType }>`
+  ${({ theme }) => theme.typography.body_medium_m};
+  color: ${(props) => getTextColor(props.type, props.theme)};
+`;
+
+const ToastDismissButton = styled.h1<{ type: ToastType }>`
+  ${({ theme }) => theme.typography.body_medium_m};
+  color: ${(props) => getTextColor(props.type, props.theme)};
+  background: transparent;
+  cursor: pointer;
+`;
+
+export function SnackBar({ text, type }: ToastProps) {
+  const { t } = useTranslation('translation');
+
+  const dismissToast = () => {
+    toast.dismiss();
+  };
+
+  return (
+    <ToastContainer type={type}>
+      <ToastMessage type={type}>{text}</ToastMessage>
+      <ToastDismissButton onClick={dismissToast} type={type}>
+        {t('OK')}
+      </ToastDismissButton>
+    </ToastContainer>
+  );
+}
+
+export default SnackBar;

--- a/src/app/ui-library/snackBar.tsx
+++ b/src/app/ui-library/snackBar.tsx
@@ -35,14 +35,17 @@ const ToastContainer = styled.div<{ type: ToastType }>`
   box-shadow: 0px 7px 16px -4px rgba(25, 25, 48, 0.25);
   height: 44px;
   padding: 12px 20px;
-  width: 306px;
+  width: auto;
+  max-width: 306px;
   align-items: center;
   justify-content: space-between;
+  margin-bottom: 80px;
 `;
 
 const ToastMessage = styled.h1<{ type: ToastType }>`
   ${({ theme }) => theme.typography.body_medium_m};
   color: ${(props) => getTextColor(props.type, props.theme)};
+  margin-right: 24px;
 `;
 
 const ToastDismissButton = styled.h1<{ type: ToastType }>`

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1112,6 +1112,9 @@
     "COLLECTION_FLOOR_PRICE": "Collection floor price",
     "EST_PORTFOLIO_VALUE": "Est. portfolio value",
     "COLLECTION": "Collection",
-    "LOAD_MORE": "Load more"
+    "LOAD_MORE": "Load more",
+    "ERRORS": {
+      "FAILED_TO_FETCH": "Failed to fetch data"
+    }
   }
 }


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background
We need to avoid navigating to NFT detail screen and show a snackbar saying 'Failed to fetch data' if metadata is not fetch properly.

Issue Link: https://linear.app/xverseapp/issue/ENG-3190/handle-the-state-when-the-meta-data-are-not-available

# 🔄 Changes
- added a snackbar component in ui-library
- show snackbar if metadata in null

Impact:
- stacks collection screen

# 🖼 Screenshot / 📹 Video

https://github.com/secretkeylabs/xverse-web-extension/assets/29428363/b9a40e5f-b4fd-4591-8679-e268c7f04e1c

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
