### PR TITLE
fix: open NFT gamma link

### DIFF
--- a/src/app/screens/nftDetail/useNftDetail.ts
+++ b/src/app/screens/nftDetail/useNftDetail.ts
@@ -19,7 +19,7 @@ export default function useNftDetail() {
     nftCollections,
   );
   const metaData = nft?.data?.token_metadata;
-  const gammaUrl = `${GAMMA_URL}collections/${nft?.data?.token_metadata?.contract_id}/${nft?.data?.token_id}`;
+  const gammaUrl = `${GAMMA_URL}collections/${metaData?.contract_id}/${nft?.data?.token_id}`;
 
   useResetUserFlow('/nft-detail');
 

--- a/src/app/screens/nftDetail/useNftDetail.ts
+++ b/src/app/screens/nftDetail/useNftDetail.ts
@@ -19,6 +19,7 @@ export default function useNftDetail() {
     nftCollections,
   );
   const metaData = nft?.data?.token_metadata;
+  const gammaUrl = `${GAMMA_URL}collections/${nft?.data?.token_metadata?.contract_id}/${nft?.data?.token_id}`;
 
   useResetUserFlow('/nft-detail');
 
@@ -27,9 +28,7 @@ export default function useNftDetail() {
     collectionId === 'bns' && nft ? getBnsNftName(nft) : nft?.data?.token_metadata.name;
 
   const onSharePress = () => {
-    navigator.clipboard.writeText(
-      `${GAMMA_URL}collections/${nft?.data?.token_metadata?.contract_id}/${nft?.data?.token_id}`,
-    );
+    navigator.clipboard.writeText(gammaUrl);
   };
 
   const handleBackButtonClick = () => {
@@ -37,8 +36,7 @@ export default function useNftDetail() {
   };
 
   const onGammaPress = () => {
-    const number = metaData?.name.split('#')[1];
-    window.open(`${GAMMA_URL}collections/${metaData?.asset_id}/${number}`);
+    window.open(gammaUrl);
   };
 
   const onExplorerPress = () => {

--- a/src/app/screens/nftDetail/useNftDetail.ts
+++ b/src/app/screens/nftDetail/useNftDetail.ts
@@ -18,6 +18,7 @@ export default function useNftDetail() {
     id,
     nftCollections,
   );
+  const metaData = nft?.data?.token_metadata;
 
   useResetUserFlow('/nft-detail');
 
@@ -36,7 +37,8 @@ export default function useNftDetail() {
   };
 
   const onGammaPress = () => {
-    window.open(`${GAMMA_URL}collections/${nft?.data?.token_metadata?.contract_id}`);
+    const number = metaData?.name.split('#')[1];
+    window.open(`${GAMMA_URL}collections/${metaData?.asset_id}/${number}`);
   };
 
   const onExplorerPress = () => {


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background
We need to open NFT page on gamma instead of the whole collection when opened from NFT detail screen

Issue Link: https://linear.app/xverseapp/issue/ENG-3186/see-detail-button-should-open-in-gamma-for-the-specific-stx-nft-not
Context Link (if applicable):

# 🔄 Changes
- changed the URL to open NFT page on gamma

Impact:
-  NFT detail screen

# 🖼 Screenshot / 📹 Video

https://github.com/secretkeylabs/xverse-web-extension/assets/29428363/bfb4790d-8b8c-4b33-b553-8dd2eb45cb2e

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
