### PR TITLE
fix: some nft images are still showing the moon loader spinner it should be

### DIFF
--- a/src/app/components/barLoader/index.tsx
+++ b/src/app/components/barLoader/index.tsx
@@ -77,8 +77,8 @@ export function BetterBarLoader({
   height,
   className,
 }: {
-  width: number;
-  height: number;
+  width: number | string;
+  height: number | string;
   className?: string;
 }) {
   return (
@@ -88,7 +88,6 @@ export function BetterBarLoader({
       interval={0.1}
       width={width}
       height={height}
-      viewBox={`0 0 ${width} ${height}`}
       backgroundColor={Theme.colors.elevation3}
       foregroundColor={Theme.colors.grey}
       className={className}

--- a/src/app/screens/nftCollection/index.tsx
+++ b/src/app/screens/nftCollection/index.tsx
@@ -180,7 +180,7 @@ function NftCollection() {
             ) : (
               collectionData?.all_nfts.map((nft) => (
                 <CollectibleCollectionGridItem
-                  key={nft.asset_identifier}
+                  key={nft.data?.fully_qualified_token_id}
                   item={nft}
                   itemId={getNftCollectionsGridItemId(nft, collectionData)}
                   onClick={handleOnClick}

--- a/src/app/screens/nftDashboard/nftImage.tsx
+++ b/src/app/screens/nftDashboard/nftImage.tsx
@@ -1,22 +1,22 @@
-import NftPlaceholderImage from '@assets/img/nftDashboard/ic_nft_diamond.svg';
 import { BetterBarLoader } from '@components/barLoader';
+import { SquareLogo } from '@phosphor-icons/react';
 import { TokenMetaData } from '@secretkeylabs/xverse-core';
 import { getFetchableUrl } from '@utils/helper';
 import Image from 'rc-image';
-import { Suspense } from 'react';
-import { MoonLoader } from 'react-spinners';
+import { Suspense, useState } from 'react';
 import styled from 'styled-components';
+import Theme from 'theme';
 
 interface ContainerProps {
   isGalleryOpen: boolean;
 }
 
-const ImageContainer = styled.div<ContainerProps>((props) => ({
+const ImageContainer = styled.div<ContainerProps>(() => ({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
   width: '100%',
-  height: props.isGalleryOpen ? '100%' : 150,
+  height: '100%',
   overflow: 'hidden',
   position: 'relative',
   borderRadius: 8,
@@ -50,34 +50,39 @@ const Video = styled.video({
 const StyledImg = styled(Image)`
   border-radius: 8px;
   object-fit: contain;
-  height: 150;
 `;
 interface Props {
   metadata: TokenMetaData;
   isInCollage?: boolean;
 }
 
+function ErrorStateImg() {
+  return <SquareLogo width="40%" height="40%" weight="light" color={Theme.colors.elevation6} />;
+}
+
 function NftImage({ metadata, isInCollage = false }: Props) {
+  const [error, setError] = useState(false);
   const isGalleryOpen: boolean = document.documentElement.clientWidth > 360;
   if (metadata?.image_protocol) {
     return (
       <ImageContainer isGalleryOpen={isGalleryOpen || isInCollage}>
-        <Suspense>
-          <StyledImg
-            width="100%"
-            preview={false}
-            src={getFetchableUrl(metadata.image_url ?? '', metadata.image_protocol ?? '')}
-            placeholder={
-              <LoaderContainer>
-                <StyledBarLoader
-                  width={isGalleryOpen ? 276 : 151}
-                  height={isGalleryOpen ? 276 : 151}
-                />
-              </LoaderContainer>
-            }
-            fallback={NftPlaceholderImage}
-          />
-        </Suspense>
+        {error ? (
+          <ErrorStateImg />
+        ) : (
+          <Suspense>
+            <StyledImg
+              width="100%"
+              preview={false}
+              src={getFetchableUrl(metadata.image_url ?? '', metadata.image_protocol ?? '')}
+              placeholder={
+                <LoaderContainer>
+                  <StyledBarLoader width="100%" height="100%" />
+                </LoaderContainer>
+              }
+              onError={() => setError(true)}
+            />
+          </Suspense>
+        )}
       </ImageContainer>
     );
   }
@@ -95,7 +100,7 @@ function NftImage({ metadata, isInCollage = false }: Props) {
 
   return (
     <ImageContainer isGalleryOpen={isGalleryOpen}>
-      <MoonLoader color="white" size={30} />
+      <ErrorStateImg />
     </ImageContainer>
   );
 }

--- a/src/assets/img/nftDashboard/ic_nft_diamond.svg
+++ b/src/assets/img/nftDashboard/ic_nft_diamond.svg
@@ -1,3 +1,0 @@
-<svg width="85" height="75" viewBox="0 0 85 75" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M4.28178 26.027L22.8923 2.90826H62.1077L80.7182 26.027L42.5 70.5358L4.28178 26.027Z" stroke="#7E89AB" stroke-width="5.81651" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>


### PR DESCRIPTION
# 🔘 PR Type

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background
This PR replace the older loading nft for a skeleton and fixes some issues in layout and wrong key prop values


Issue Link: #[ENG-3202](https://linear.app/xverseapp/issue/ENG-3202/some-nft-images-are-still-showing-the-moon-loader-spinner-it-should-be)


# 🔄 Changes
- tweak BetterBarLoader component to receive string as width and height in order to user percentages
- fix key prop in nft collection screen
- remove hardcoded placeholder size values and replace error icon with the new one


# 🖼 Screenshot / 📹 Video
| BEFORE | AFTER |
| :---: | :---: |
| <video src='https://github.com/secretkeylabs/xverse-web-extension/assets/18606335/a8c35a6e-2af3-4121-bc7f-d23628344436'> | <video src='https://github.com/secretkeylabs/xverse-web-extension/assets/18606335/878c4a16-93ba-4c99-919e-80e9cf1a82d7'> |


# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
