### PR TITLE
chore: bump sats-connect to 1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "redux": "^4.0.5",
         "redux-persist": "^6.0.0",
         "redux-state-sync": "^3.1.4",
-        "sats-connect": "1.1.1",
+        "sats-connect": "1.1.2",
         "stream-browserify": "^3.0.0",
         "string-to-color": "^2.2.2",
         "styled-components": "^5.3.5",
@@ -16462,9 +16462,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sats-connect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/sats-connect/-/sats-connect-1.1.1.tgz",
-      "integrity": "sha512-cckwlFc0gnYNZsNUsH9xACcpIeD+XdbSvtYhkGZSRqNeqzbqgdVI50mD4mzxs1ILbUGLjdTCINohVP6WbbvhcA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sats-connect/-/sats-connect-1.1.2.tgz",
+      "integrity": "sha512-nJmCV69WgMNGH9H2cTTH/HsO9wEYS7g0AvnCNNgY5fezEJmA6jNpRMP4Xidv/c0xWL1uGOUHPLJEEOSG4NoneQ==",
       "dependencies": {
         "jsontokens": "^4.0.1",
         "process": "^0.11.10",
@@ -31525,9 +31525,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sats-connect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/sats-connect/-/sats-connect-1.1.1.tgz",
-      "integrity": "sha512-cckwlFc0gnYNZsNUsH9xACcpIeD+XdbSvtYhkGZSRqNeqzbqgdVI50mD4mzxs1ILbUGLjdTCINohVP6WbbvhcA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sats-connect/-/sats-connect-1.1.2.tgz",
+      "integrity": "sha512-nJmCV69WgMNGH9H2cTTH/HsO9wEYS7g0AvnCNNgY5fezEJmA6jNpRMP4Xidv/c0xWL1uGOUHPLJEEOSG4NoneQ==",
       "requires": {
         "jsontokens": "^4.0.1",
         "process": "^0.11.10",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "redux": "^4.0.5",
     "redux-persist": "^6.0.0",
     "redux-state-sync": "^3.1.4",
-    "sats-connect": "1.1.1",
+    "sats-connect": "1.1.2",
     "stream-browserify": "^3.0.0",
     "string-to-color": "^2.2.2",
     "styled-components": "^5.3.5",


### PR DESCRIPTION
# 🔘 PR Type
- [x] Enhancement

# 📜 Background
- bump sats-connect to [1.1.2](https://github.com/secretkeylabs/sats-connect/releases/tag/v1.1.2)

# 🔄 Changes
Impact:
- allow inscribing on testnet

# 🖼 Screenshot / 📹 Video
Include screenshots or a video demonstrating the changes. This is especially helpful for UI changes.

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
