### PR TITLE
fix: bns image size and disable click on bns item

### DIFF
--- a/src/app/components/collectibleCollectionGridItem/index.tsx
+++ b/src/app/components/collectibleCollectionGridItem/index.tsx
@@ -44,6 +44,7 @@ const GridItemContainer = styled.button`
   background: transparent;
   gap: ${(props) => props.theme.space.s};
   cursor: ${(props) => (props.onClick ? 'pointer' : 'initial')};
+  width: 100%;
 `;
 
 interface Props {

--- a/src/app/hooks/queries/useNftDetail.ts
+++ b/src/app/hooks/queries/useNftDetail.ts
@@ -1,6 +1,6 @@
 import { getNftDetail, NftDetailResponse, NonFungibleToken } from '@secretkeylabs/xverse-core';
 import { useQuery } from '@tanstack/react-query';
-import { getIdentifier } from '@utils/nfts';
+import { getIdentifier, isBnsCollection } from '@utils/nfts';
 import { handleRetries } from '@utils/query';
 
 const useNftDetail = (id: string | NonFungibleToken['identifier']) => {
@@ -11,7 +11,13 @@ const useNftDetail = (id: string | NonFungibleToken['identifier']) => {
     getNftDetail(tokenId, contractAddress, contractName);
 
   return useQuery({
-    enabled: !!(id && tokenId && contractAddress && contractName),
+    enabled: !!(
+      id &&
+      tokenId &&
+      contractAddress &&
+      contractName &&
+      !isBnsCollection(`${contractAddress}.${contractName}`)
+    ),
     retry: handleRetries,
     queryKey: ['nft-detail', contractAddress, contractName, tokenId],
     queryFn: fetchNft,

--- a/src/app/screens/nftCollection/index.tsx
+++ b/src/app/screens/nftCollection/index.tsx
@@ -115,6 +115,10 @@ const StyledGridContainer = styled(GridContainer)`
   width: 100%;
 `;
 
+/*
+ * component to virtualise the grid item if not in window
+ * placeholder is required to match grid item size, in order to negate scroll jank
+ */
 function IsVisibleOrPlaceholder({ children }: PropsWithChildren) {
   const nodeRef = useRef<HTMLDivElement>(null);
   const isVisible = useIsVisible(nodeRef, { once: false });
@@ -132,6 +136,9 @@ function IsVisibleOrPlaceholder({ children }: PropsWithChildren) {
   );
 }
 
+/*
+ * component to load nft detail which contains image url
+ */
 function CollectionGridItemWithData({
   nft,
   collectionData,
@@ -145,7 +152,7 @@ function CollectionGridItemWithData({
   const navigate = useNavigate();
   const { t } = useTranslation('translation', { keyPrefix: 'COLLECTIBLE_COLLECTION_SCREEN' });
 
-  const handleClickItem = isBnsCollection(nft.asset_identifier)
+  const handleClickItem = isBnsCollection(collectionData.collection_id)
     ? undefined
     : () => {
         if (nftData?.data?.token_metadata) {
@@ -161,7 +168,7 @@ function CollectionGridItemWithData({
       itemId={getNftCollectionsGridItemId(nft, collectionData)}
       onClick={handleClickItem}
     >
-        <Nft asset={nft} isGalleryOpen={isGalleryOpen} />
+      <Nft asset={nft} isGalleryOpen={isGalleryOpen} />
     </CollectibleCollectionGridItem>
   );
 }


### PR DESCRIPTION
# 🔘 PR Type
- [x] Bugfix

# 📜 Background
https://linear.app/xverseapp/issue/ENG-3290/bns-domain-failed-to-fetch-data-snackbar-issue
https://linear.app/xverseapp/issue/ENG-3291/bns-domain-thumbnail-size-when-in-fullscreen

# 🔄 Changes
- fix: bns thumbnail image was not showing full size
- fix: bns thumbnail should not be clickable on the bns collection screen
- fix: disable the useDetail fetch for bns items (I think @fedeerbes mentioned this in another PR review)

Impact:
- bns thumbnail
- I checked the loading sizes of other thumbnails and they still look correct

# 🖼 Screenshot / 📹 Video

https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/4334e7a3-8680-4024-b1fb-dfec35d60fc7


# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
