### PR TITLE
fix: fiat rates not fetching when user changed currency

### DIFF
--- a/src/app/hooks/queries/ordinals/useAddressRareSats.ts
+++ b/src/app/hooks/queries/ordinals/useAddressRareSats.ts
@@ -53,7 +53,7 @@ export const useGetUtxoOrdinalBundle = (output?: string, shouldMakeTheCall?: boo
 
   const { data, isLoading } = useQuery({
     enabled: !!(output && shouldMakeTheCall),
-    queryKey: ['rare-sats', output],
+    queryKey: ['rare-sats', output, network.type],
     queryFn: getUtxoOrdinalBundleByOutput,
     retry: handleRetries,
     staleTime: 1 * 60 * 1000, // 1 min

--- a/src/app/hooks/queries/ordinals/useCollectionMarketData.ts
+++ b/src/app/hooks/queries/ordinals/useCollectionMarketData.ts
@@ -18,7 +18,7 @@ const useInscriptionCollectionMarketData = (collectionId?: string | null) => {
   return useQuery({
     enabled: !!collectionId,
     retry: handleRetries,
-    queryKey: ['collection-market-data', collectionId],
+    queryKey: ['collection-market-data', collectionId, network.type],
     queryFn: collectionMarketData,
     staleTime: 1 * 60 * 1000, // 1 min
   });

--- a/src/app/hooks/queries/useCoinRates.ts
+++ b/src/app/hooks/queries/useCoinRates.ts
@@ -22,7 +22,7 @@ export const useCoinRates = () => {
   };
 
   return useQuery({
-    queryKey: ['coin_rates'],
+    queryKey: ['coin_rates', fiatCurrency, network.type],
     queryFn: fetchCoinRates,
     staleTime: 5 * 60 * 1000, // 5 min
   });

--- a/src/app/hooks/useTextOrdinalContent.ts
+++ b/src/app/hooks/useTextOrdinalContent.ts
@@ -9,7 +9,7 @@ const queue = new PQueue({ concurrency: 1 });
 const useTextOrdinalContent = (ordinal: Inscription | CondensedInscription) => {
   const { network } = useWalletSelector();
   const { data: textContent } = useQuery({
-    queryKey: [`ordinal-text-${ordinal?.id}`],
+    queryKey: ['ordinal-text', ordinal?.id, network.type],
     queryFn: async () => queue.add(() => getTextOrdinalContent(network.type, ordinal?.id)),
     staleTime: 5 * 60 * 1000, // 5 min
   });


### PR DESCRIPTION
# 🔘 PR Type
- [x] Bugfix

# 📜 Background
https://secretkeylabs.slack.com/archives/C05QCJM9D1N/p1700550855171529

# 🔄 Changes
- fix: use correct cache keys where staleTime was introduced, but previously cache keys were too broad

Impact:
- also made sure other changed queries in the same commit have enough params in their query cache keys (it could have resulted in bugs where data was cached between switching testnet/mainnet, but would have been very rare because you the other queries were still caching by id as well)


# 🖼 Screenshot / 📹 Video

https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/f15a077c-87e1-4e43-aafa-385235eef220



# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
