### PR TITLE
Replace hardcoded USD with dynamic NumericFormat prefix

### DIFF
--- a/src/app/screens/swap/swapTokenBlock/index.tsx
+++ b/src/app/screens/swap/swapTokenBlock/index.tsx
@@ -1,7 +1,10 @@
 import ChevronIcon from '@assets/img/swap/chevron.svg';
 import TokenImage from '@components/tokenImage';
+import useWalletSelector from '@hooks/useWalletSelector';
 import { SwapToken } from '@screens/swap/types';
+import { currencySymbolMap } from '@secretkeylabs/xverse-core/types/currency';
 import { useTranslation } from 'react-i18next';
+import { NumericFormat } from 'react-number-format';
 import styled from 'styled-components';
 
 const Container = styled.div((props) => ({
@@ -115,6 +118,7 @@ function SwapTokenBlock({
   error,
 }: SwapTokenBlockProps) {
   const { t } = useTranslation('translation', { keyPrefix: 'SWAP_SCREEN' });
+  const { fiatCurrency } = useWalletSelector();
 
   return (
     <Container>
@@ -141,9 +145,14 @@ function SwapTokenBlock({
           />
         </RowContainer>
         <RowContainer>
-          <EstimateUSDText>
-            {selectedCoin?.fiatAmount ? `≈ $ ${selectedCoin.fiatAmount} USD` : '--'}
-          </EstimateUSDText>
+          <NumericFormat
+            value={selectedCoin?.fiatAmount ?? '--'}
+            displayType="text"
+            thousandSeparator
+            prefix={`${currencySymbolMap[fiatCurrency]} `}
+            suffix={` ${fiatCurrency}`}
+            renderText={(value) => <EstimateUSDText>{value}</EstimateUSDText>}
+          />
         </RowContainer>
       </CardContainer>
     </Container>


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background
Provide a brief explanation of why this pull request is needed. Include the problem you are solving or the functionality you are adding. Reference any related issues.

Switching currency doesn't update the currency symbol in the swap asset drawer.

Issue Link: ENG-2691
Context Link (if applicable):

# 🔄 Changes
Enumerate the changes made in this pull request, detailing what has been modified, added, or removed. Include technical details and implications if necessary.

Impact:
- Explain the broader impact of these changes.
- How it improves performance, fixes bugs, adds functionality, etc.

The currency symbol was previously hardcoded to "USD". 

# 🖼 Screenshot / 📹 Video
Include screenshots or a video demonstrating the changes. This is especially helpful for UI changes.

Before: 
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/65149726/cda4562c-f433-45bc-8b7d-52aea6cad6ad)

After:
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/65149726/8df76ee8-ec07-4cea-b117-65fc7bab7637)

Note: Another bug is present in the screenshots above, fixed here: #669

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
