### PR TITLE
fix: reset selected state after sending an ordinal or rare sat bundle

### DIFF
--- a/src/app/screens/confirmOrdinalTransaction/index.tsx
+++ b/src/app/screens/confirmOrdinalTransaction/index.tsx
@@ -6,6 +6,8 @@ import BottomBar from '@components/tabBar';
 import { useGetUtxoOrdinalBundle } from '@hooks/queries/ordinals/useAddressRareSats';
 import useBtcWalletData from '@hooks/queries/useBtcWalletData';
 import useNftDataSelector from '@hooks/stores/useNftDataSelector';
+import useOrdinalDataReducer from '@hooks/stores/useOrdinalReducer';
+import useSatBundleDataReducer from '@hooks/stores/useSatBundleReducer';
 import useBtcClient from '@hooks/useBtcClient';
 import { useResetUserFlow } from '@hooks/useResetUserFlow';
 import useWalletSelector from '@hooks/useWalletSelector';
@@ -74,6 +76,8 @@ function ConfirmOrdinalTransaction() {
   }
 
   const { selectedOrdinal, selectedSatBundle } = useNftDataSelector();
+  const { setSelectedOrdinalDetails } = useOrdinalDataReducer();
+  const { setSelectedSatBundleDetails } = useSatBundleDataReducer();
   const { refetch } = useBtcWalletData();
   const [currentFee, setCurrentFee] = useState(fee);
   const [currentFeeRate, setCurrentFeeRate] = useState(feePerVByte);
@@ -96,6 +100,8 @@ function ConfirmOrdinalTransaction() {
 
   useEffect(() => {
     if (btcTxBroadcastData) {
+      setSelectedOrdinalDetails(null);
+      setSelectedSatBundleDetails(null);
       navigate('/tx-status', {
         state: {
           txid: btcTxBroadcastData.tx.hash,
@@ -113,6 +119,8 @@ function ConfirmOrdinalTransaction() {
 
   useEffect(() => {
     if (txError) {
+      setSelectedOrdinalDetails(null);
+      setSelectedSatBundleDetails(null);
       navigate('/tx-status', {
         state: {
           txid: '',


### PR DESCRIPTION
# 🔘 PR Type
- [x] Bugfix

# 📜 Background
quickfix for seeing previously sent ordinals in the send ordinal screen

# 🔄 Changes

Impact:
- confirm ordinal screen only after clicking next only

# 🖼 Screenshot / 📹 Video
Include screenshots or a video demonstrating the changes. This is especially helpful for UI changes.

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
