### PR TITLE
fix: correctly parse bns names on testnet

### DIFF
--- a/src/app/screens/nftDashboard/nft.tsx
+++ b/src/app/screens/nftDashboard/nft.tsx
@@ -1,7 +1,7 @@
 import NftUser from '@assets/img/nftDashboard/bns.svg';
 import useNftDetail from '@hooks/queries/useNftDetail';
 import { NonFungibleToken } from '@secretkeylabs/xverse-core';
-import { BNS_CONTRACT } from '@utils/constants';
+import { isBnsContract } from '@utils/nfts';
 import styled from 'styled-components';
 import NftImage from './nftImage';
 
@@ -48,7 +48,7 @@ function Nft({ asset, isGalleryOpen }: Props) {
   return (
     <GridItemContainer>
       <NftImageContainer isGalleryView={isGalleryOpen}>
-        {asset.asset_identifier === BNS_CONTRACT ? (
+        {isBnsContract(asset?.asset_identifier) ? (
           <BnsImage src={NftUser} alt="user" />
         ) : (
           <NftImage metadata={data?.data?.token_metadata} isInCollage />

--- a/src/app/utils/constants.ts
+++ b/src/app/utils/constants.ts
@@ -7,7 +7,6 @@ import {
   HIRO_TESTNET_DEFAULT,
 } from '@secretkeylabs/xverse-core/constant';
 
-export const BNS_CONTRACT = 'SP000000000000000000002Q6VF78.bns::names';
 export const GAMMA_URL = 'https://gamma.io/';
 export const TERMS_LINK = 'https://xverse.app/terms';
 export const PRIVACY_POLICY_LINK = 'https://xverse.app/privacy';

--- a/src/app/utils/nfts.ts
+++ b/src/app/utils/nfts.ts
@@ -4,7 +4,12 @@ export const getNftsTabGridItemSubText = (collection: StacksCollectionData) =>
   collection?.all_nfts?.length > 1 ? `${collection.all_nfts.length} Items` : '1 Item';
 
 export const isBnsCollection = (collectionId?: string | null): boolean =>
-  collectionId === 'SP000000000000000000002Q6VF78.bns';
+  collectionId === 'SP000000000000000000002Q6VF78.bns' ||
+  collectionId === 'ST000000000000000000002AMW42H.bns'; // testnet
+
+export const isBnsContract = (assetIdentifier?: string): boolean =>
+  assetIdentifier === 'SP000000000000000000002Q6VF78.bns::names' ||
+  assetIdentifier === 'ST000000000000000000002AMW42H.bns::names'; // testnet
 
 // fully_qualified_token_id like:
 // SP1E1RNN4JZ7T6Y0JVCSY2TH4918Z590P8JAB9HZM.radboy-first-feat::radboy-first-feat:64


### PR DESCRIPTION
# 🔘 PR Type
- [x] Bugfix

# 📜 Background
https://linear.app/xverseapp/issue/ENG-3308/correctly-detect-bns-collections-on-testnet

# 🔄 Changes
- fix: determine if the collection / asset is bns name by matching both mainnet and testnet contracts

Impact:
- nft tab (bns name collection)
- nft collection screen (bns item)


# 🖼 Screenshot / 📹 Video

mainnet:
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/4847aca8-3f5b-4d5d-a631-7e52387c4eac)

testnet:
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/40b6bd34-e65a-41ba-8789-998966987b0c)


# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
