### PR TITLE
fix: use isInitialLoading so skeleton loader shows only if query is e…

### DIFF
--- a/src/app/screens/nftDashboard/collectiblesTabs.tsx
+++ b/src/app/screens/nftDashboard/collectiblesTabs.tsx
@@ -171,7 +171,7 @@ export default function CollectiblesTabs({
       )}
       {hasActivatedOrdinalsKey && (
         <TabPanel>
-          {inscriptionsQuery.isLoading ? (
+          {inscriptionsQuery.isInitialLoading ? (
             <SkeletonLoader isGalleryOpen={isGalleryOpen} />
           ) : (
             <>
@@ -186,7 +186,7 @@ export default function CollectiblesTabs({
         </TabPanel>
       )}
       <TabPanel>
-        {stacksNftsQuery.isLoading ? (
+        {stacksNftsQuery.isInitialLoading ? (
           <SkeletonLoader isGalleryOpen={isGalleryOpen} />
         ) : (
           <>
@@ -224,7 +224,7 @@ export default function CollectiblesTabs({
           {showNoBundlesNotice && <NoCollectiblesText>{t('NO_COLLECTIBLES')}</NoCollectiblesText>}
 
           {!!rareSatsQuery.error && <StyledWrenchErrorMessage />}
-          {rareSatsQuery.isLoading ? (
+          {rareSatsQuery.isInitialLoading ? (
             <SkeletonLoader isGalleryOpen={isGalleryOpen} />
           ) : (
             <GridContainer isGalleryOpen={isGalleryOpen}>

--- a/src/app/screens/nftDashboard/index.tsx
+++ b/src/app/screens/nftDashboard/index.tsx
@@ -4,14 +4,12 @@ import ActionButton from '@components/button';
 import ShowOrdinalReceiveAlert from '@components/showOrdinalReceiveAlert';
 import BottomTabBar from '@components/tabBar';
 import WebGalleryButton from '@components/webGalleryButton';
-
 import { ArrowDown } from '@phosphor-icons/react';
 import { StyledHeading } from '@ui-library/common.styled';
 import Dialog from '@ui-library/dialog';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import CollectiblesTabs from './collectiblesTabs';
-
 import ReceiveNftModal from './receiveNft';
 import { useNftDashboard } from './useNftDashboard';
 
@@ -98,7 +96,6 @@ function NftDashboard() {
       {isOrdinalReceiveAlertVisible && (
         <ShowOrdinalReceiveAlert onOrdinalReceiveAlertClose={onOrdinalReceiveAlertClose} />
       )}
-
       {showNewFeatureAlert && (
         <Dialog
           title={t('NEW_FEATURE')}
@@ -116,7 +113,6 @@ function NftDashboard() {
           icon={<img src={FeatureIcon} width="60" height="60" alt="new feature" />}
         />
       )}
-
       <AccountHeaderComponent disableMenuOption={isGalleryOpen} showBorderBottom={false} />
       <Container>
         <PageHeader>
@@ -152,10 +148,8 @@ function NftDashboard() {
           nftDashboard={nftDashboard}
         />
       </Container>
-
       {!isGalleryOpen && <BottomTabBar tab="nft" />}
     </>
   );
 }
-
 export default NftDashboard;


### PR DESCRIPTION
…nabled

# 🔘 PR Type
- [x] Bugfix

# 📜 Background
https://linear.app/xverseapp/issue/ENG-3307/for-ledger-users-who-havent-activated-stx-yet-they-see-a-skeleton

# 🔄 Changes
- fix: should use isInitialLoading to display skeleton loader only if query is loading and fetching first time (not disabled)

Impact:
- nfts tab and inscriptions tab only

# 🖼 Screenshot / 📹 Video
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/63f60fb4-1593-46a4-82db-8c0d68d634c8)


# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
