### PR TITLE
Inject esplora provider into core functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ledgerhq/hw-transport-webusb": "^6.27.13",
         "@phosphor-icons/react": "^2.0.10",
         "@react-spring/web": "^9.6.1",
-        "@secretkeylabs/xverse-core": "5.0.0-a42f01f",
+        "@secretkeylabs/xverse-core": "5.1.0-4ae7712",
         "@stacks/connect": "^6.10.2",
         "@stacks/encryption": "4.3.5",
         "@stacks/stacks-blockchain-api-types": "6.1.1",
@@ -1727,9 +1727,9 @@
       }
     },
     "node_modules/@secretkeylabs/xverse-core": {
-      "version": "5.0.0-a42f01f",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/5.0.0-a42f01f/bb3981ff13b9c49db85dcd2a3a492049670fe9fd",
-      "integrity": "sha512-7Cu8oIVNK39fw+02BTO4oi5aLEyNe01/f0gLwenS0t69gp0jHNK5VzHJCtahsbOtWIQR6B+mCsxgOeNGfs38ZQ==",
+      "version": "5.1.0-4ae7712",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/5.1.0-4ae7712/f84e5ad0e8a2a8d578cae1d10a6ed5eb0d14b0ed",
+      "integrity": "sha512-LFVfuKlItMtmvSI1qxM82arjhC7SVJmVe/5IaMO46FIYFRY4rxMoaFZMWWJGMy3HJy2JbnhzB8OChkfbyrcxBQ==",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
@@ -16046,9 +16046,9 @@
       }
     },
     "@secretkeylabs/xverse-core": {
-      "version": "5.0.0-a42f01f",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/5.0.0-a42f01f/bb3981ff13b9c49db85dcd2a3a492049670fe9fd",
-      "integrity": "sha512-7Cu8oIVNK39fw+02BTO4oi5aLEyNe01/f0gLwenS0t69gp0jHNK5VzHJCtahsbOtWIQR6B+mCsxgOeNGfs38ZQ==",
+      "version": "5.1.0-4ae7712",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/5.1.0-4ae7712/f84e5ad0e8a2a8d578cae1d10a6ed5eb0d14b0ed",
+      "integrity": "sha512-LFVfuKlItMtmvSI1qxM82arjhC7SVJmVe/5IaMO46FIYFRY4rxMoaFZMWWJGMy3HJy2JbnhzB8OChkfbyrcxBQ==",
       "requires": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
         "@noble/secp256k1": "^1.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ledgerhq/hw-transport-webusb": "^6.27.13",
         "@phosphor-icons/react": "^2.0.10",
         "@react-spring/web": "^9.6.1",
-        "@secretkeylabs/xverse-core": "5.1.0-4ae7712",
+        "@secretkeylabs/xverse-core": "5.2.0",
         "@stacks/connect": "^6.10.2",
         "@stacks/encryption": "4.3.5",
         "@stacks/stacks-blockchain-api-types": "6.1.1",
@@ -1727,9 +1727,9 @@
       }
     },
     "node_modules/@secretkeylabs/xverse-core": {
-      "version": "5.1.0-4ae7712",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/5.1.0-4ae7712/f84e5ad0e8a2a8d578cae1d10a6ed5eb0d14b0ed",
-      "integrity": "sha512-LFVfuKlItMtmvSI1qxM82arjhC7SVJmVe/5IaMO46FIYFRY4rxMoaFZMWWJGMy3HJy2JbnhzB8OChkfbyrcxBQ==",
+      "version": "5.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/5.2.0/f4d46eacac2b7be0b6fb70ce5184d1c10ed7bfa6",
+      "integrity": "sha512-DhDrTAFYPHf22ThYn+z9DIlxXN6M7jH5JEbAi5I58xE62RsEOcpxfRHDhfNzcNAyWKJEXzChkbOp7OpFHLIF1w==",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
@@ -16046,9 +16046,9 @@
       }
     },
     "@secretkeylabs/xverse-core": {
-      "version": "5.1.0-4ae7712",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/5.1.0-4ae7712/f84e5ad0e8a2a8d578cae1d10a6ed5eb0d14b0ed",
-      "integrity": "sha512-LFVfuKlItMtmvSI1qxM82arjhC7SVJmVe/5IaMO46FIYFRY4rxMoaFZMWWJGMy3HJy2JbnhzB8OChkfbyrcxBQ==",
+      "version": "5.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/5.2.0/f4d46eacac2b7be0b6fb70ce5184d1c10ed7bfa6",
+      "integrity": "sha512-DhDrTAFYPHf22ThYn+z9DIlxXN6M7jH5JEbAi5I58xE62RsEOcpxfRHDhfNzcNAyWKJEXzChkbOp7OpFHLIF1w==",
       "requires": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
         "@noble/secp256k1": "^1.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ledgerhq/hw-transport-webusb": "^6.27.13",
         "@phosphor-icons/react": "^2.0.10",
         "@react-spring/web": "^9.6.1",
-        "@secretkeylabs/xverse-core": "4.1.0",
+        "@secretkeylabs/xverse-core": "5.0.0-a42f01f",
         "@stacks/connect": "^6.10.2",
         "@stacks/encryption": "4.3.5",
         "@stacks/stacks-blockchain-api-types": "6.1.1",
@@ -1727,9 +1727,9 @@
       }
     },
     "node_modules/@secretkeylabs/xverse-core": {
-      "version": "4.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/4.1.0/b8eaf1ac953cbc06959ae2f5e59544dd6b9d053c",
-      "integrity": "sha512-nkKyXZMAWCEohfrpQCsmgEQrz/Tdhl8KOoF1ptOIDRzKx75I7m2b8UOAC4eKgwzShAZSg0izxRxWoLuMSv/EiA==",
+      "version": "5.0.0-a42f01f",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/5.0.0-a42f01f/bb3981ff13b9c49db85dcd2a3a492049670fe9fd",
+      "integrity": "sha512-7Cu8oIVNK39fw+02BTO4oi5aLEyNe01/f0gLwenS0t69gp0jHNK5VzHJCtahsbOtWIQR6B+mCsxgOeNGfs38ZQ==",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
@@ -16046,9 +16046,9 @@
       }
     },
     "@secretkeylabs/xverse-core": {
-      "version": "4.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/4.1.0/b8eaf1ac953cbc06959ae2f5e59544dd6b9d053c",
-      "integrity": "sha512-nkKyXZMAWCEohfrpQCsmgEQrz/Tdhl8KOoF1ptOIDRzKx75I7m2b8UOAC4eKgwzShAZSg0izxRxWoLuMSv/EiA==",
+      "version": "5.0.0-a42f01f",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/5.0.0-a42f01f/bb3981ff13b9c49db85dcd2a3a492049670fe9fd",
+      "integrity": "sha512-7Cu8oIVNK39fw+02BTO4oi5aLEyNe01/f0gLwenS0t69gp0jHNK5VzHJCtahsbOtWIQR6B+mCsxgOeNGfs38ZQ==",
       "requires": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
         "@noble/secp256k1": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@ledgerhq/hw-transport-webusb": "^6.27.13",
     "@phosphor-icons/react": "^2.0.10",
     "@react-spring/web": "^9.6.1",
-    "@secretkeylabs/xverse-core": "4.1.0",
+    "@secretkeylabs/xverse-core": "5.0.0-a42f01f",
     "@stacks/connect": "^6.10.2",
     "@stacks/encryption": "4.3.5",
     "@stacks/stacks-blockchain-api-types": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@ledgerhq/hw-transport-webusb": "^6.27.13",
     "@phosphor-icons/react": "^2.0.10",
     "@react-spring/web": "^9.6.1",
-    "@secretkeylabs/xverse-core": "5.0.0-a42f01f",
+    "@secretkeylabs/xverse-core": "5.1.0-4ae7712",
     "@stacks/connect": "^6.10.2",
     "@stacks/encryption": "4.3.5",
     "@stacks/stacks-blockchain-api-types": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@ledgerhq/hw-transport-webusb": "^6.27.13",
     "@phosphor-icons/react": "^2.0.10",
     "@react-spring/web": "^9.6.1",
-    "@secretkeylabs/xverse-core": "5.1.0-4ae7712",
+    "@secretkeylabs/xverse-core": "5.2.0",
     "@stacks/connect": "^6.10.2",
     "@stacks/encryption": "4.3.5",
     "@stacks/stacks-blockchain-api-types": "6.1.1",

--- a/src/app/components/confirmBtcTransactionComponent/index.tsx
+++ b/src/app/components/confirmBtcTransactionComponent/index.tsx
@@ -6,6 +6,7 @@ import RecipientComponent from '@components/recipientComponent';
 import TransactionSettingAlert from '@components/transactionSetting';
 import TransferFeeView from '@components/transferFeeView';
 import useNftDataSelector from '@hooks/stores/useNftDataSelector';
+import useBtcClient from '@hooks/useBtcClient';
 import useOrdinalsByAddress from '@hooks/useOrdinalsByAddress';
 import useSeedVault from '@hooks/useSeedVault';
 import useWalletSelector from '@hooks/useWalletSelector';
@@ -177,6 +178,7 @@ function ConfirmBtcTransactionComponent({
   const [signedTx, setSignedTx] = useState(signedTxHex);
   const [total, setTotal] = useState<BigNumber>(new BigNumber(0));
   const [showFeeWarning, setShowFeeWarning] = useState(false);
+  const btcClient = useBtcClient();
 
   const bundle = selectedSatBundle ?? ordinalBundle ?? undefined;
   const {
@@ -199,6 +201,7 @@ function ConfirmBtcTransactionComponent({
         btcAddress,
         selectedAccount?.id ?? 0,
         seedPhrase,
+        btcClient,
         network.type,
         new BigNumber(txFee),
       ),
@@ -250,6 +253,7 @@ function ConfirmBtcTransactionComponent({
         btcAddress,
         Number(selectedAccount?.id),
         seedPhrase,
+        btcClient,
         network.type,
         ordinalsUtxos,
         new BigNumber(txFee),

--- a/src/app/components/transactionSetting/editFee.tsx
+++ b/src/app/components/transactionSetting/editFee.tsx
@@ -1,3 +1,4 @@
+import useBtcClient from '@hooks/useBtcClient';
 import useDebounce from '@hooks/useDebounce';
 import useOrdinalsByAddress from '@hooks/useOrdinalsByAddress';
 import useWalletSelector from '@hooks/useWalletSelector';
@@ -190,6 +191,7 @@ function EditFee({
   const isStx = type === 'STX';
   const { ordinals } = useOrdinalsByAddress(btcAddress);
   const ordinalsUtxos = useMemo(() => ordinals?.map((ord) => ord.utxo), [ordinals]);
+  const btcClient = useBtcClient();
 
   const modifyStxFees = (mode: string) => {
     const currentFee = new BigNumber(fee);
@@ -237,6 +239,7 @@ function EditFee({
           const { fee: modifiedFee, selectedFeeRate } = await getBtcFees(
             btcRecipients,
             btcAddress,
+            btcClient,
             network.type,
             mode,
           );
@@ -248,6 +251,7 @@ function EditFee({
           btcRecipients[0].address,
           ordinalTxUtxo,
           btcAddress,
+          btcClient,
           network.type,
           ordinalsUtxos || [],
           mode,
@@ -297,6 +301,7 @@ function EditFee({
           const { fee: modifiedFee, selectedFeeRate } = await getBtcFees(
             btcRecipients,
             btcAddress,
+            btcClient,
             network.type,
             feeMode,
             feeRateInput,
@@ -322,6 +327,7 @@ function EditFee({
           btcRecipients[0].address,
           ordinalTxUtxo,
           btcAddress,
+          btcClient,
           network.type,
           ordinalsUtxos || [],
           feeMode,

--- a/src/app/hooks/queries/useTransactions.ts
+++ b/src/app/hooks/queries/useTransactions.ts
@@ -1,3 +1,4 @@
+import useBtcClient from '@hooks/useBtcClient';
 import useWalletSelector from '@hooks/useWalletSelector';
 import type { Brc20HistoryTransactionData, BtcTransactionData } from '@secretkeylabs/xverse-core';
 import { fetchBtcTransactionsData, getBrc20History } from '@secretkeylabs/xverse-core';
@@ -14,6 +15,8 @@ export default function useTransactions(coinType: CurrencyTypes, brc20Token: str
   const { network, stxAddress, btcAddress, ordinalsAddress, hasActivatedOrdinalsKey } =
     useWalletSelector();
   const selectedNetwork = useNetworkSelector();
+  const btcClient = useBtcClient();
+
   const fetchTransactions = async (): Promise<
     | BtcTransactionData[]
     | (AddressTransactionWithTransfers | MempoolTransaction)[]
@@ -26,7 +29,7 @@ export default function useTransactions(coinType: CurrencyTypes, brc20Token: str
       const btcData = await fetchBtcTransactionsData(
         btcAddress,
         ordinalsAddress,
-        network.type,
+        btcClient,
         hasActivatedOrdinalsKey as boolean,
       );
       return btcData;

--- a/src/app/hooks/useBtcClient.ts
+++ b/src/app/hooks/useBtcClient.ts
@@ -1,39 +1,20 @@
 import { BitcoinEsploraApiProvider } from '@secretkeylabs/xverse-core';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import useWalletSelector from './useWalletSelector';
 
 const useBtcClient = () => {
   const { network, btcApiUrl } = useWalletSelector();
   const { type, btcApiUrl: remoteBtcApiURL } = network;
+  const url = btcApiUrl || remoteBtcApiURL;
 
   const esploraInstance = useMemo(
     () =>
       new BitcoinEsploraApiProvider({
-        url: remoteBtcApiURL,
+        url,
         network: type,
       }),
-    [btcApiUrl, type, remoteBtcApiURL],
+    [url, type],
   );
-
-  useEffect(() => {
-    if (btcApiUrl) {
-      esploraInstance.bitcoinApi.interceptors.request.use(
-        async (config) => {
-          config.baseURL = btcApiUrl;
-          return config;
-        },
-        (error) => Promise.reject(error),
-      );
-    } else {
-      esploraInstance.bitcoinApi.interceptors.request.use(
-        async (config) => {
-          config.baseURL = remoteBtcApiURL;
-          return config;
-        },
-        (error) => Promise.reject(error),
-      );
-    }
-  }, [btcApiUrl, remoteBtcApiURL]);
 
   return esploraInstance;
 };

--- a/src/app/hooks/useNonOrdinalUtxo.ts
+++ b/src/app/hooks/useNonOrdinalUtxo.ts
@@ -2,19 +2,21 @@ import { getNonOrdinalUtxo, UTXO } from '@secretkeylabs/xverse-core';
 import { useQuery } from '@tanstack/react-query';
 import { REFETCH_UNSPENT_UTXO_TIME } from '@utils/constants';
 import { getTimeForNonOrdinalTransferTransaction } from '@utils/localStorage';
+import useBtcClient from './useBtcClient';
 import useWalletSelector from './useWalletSelector';
 
 const useNonOrdinalUtxos = () => {
   const { network, ordinalsAddress } = useWalletSelector();
+  const btcClient = useBtcClient();
 
   const fetchNonOrdinalUtxo = async () => {
     const lastTransactionTime = await getTimeForNonOrdinalTransferTransaction(ordinalsAddress);
     if (!lastTransactionTime) {
-      return getNonOrdinalUtxo(ordinalsAddress, network.type);
+      return getNonOrdinalUtxo(ordinalsAddress, btcClient, network.type);
     }
     const diff = new Date().getTime() - Number(lastTransactionTime);
     if (diff > REFETCH_UNSPENT_UTXO_TIME) {
-      return getNonOrdinalUtxo(ordinalsAddress, network.type);
+      return getNonOrdinalUtxo(ordinalsAddress, btcClient, network.type);
     }
     return [] as UTXO[];
   };

--- a/src/app/hooks/useOrdinalsByAddress.ts
+++ b/src/app/hooks/useOrdinalsByAddress.ts
@@ -1,11 +1,14 @@
 import { BtcOrdinal, getOrdinalsByAddress } from '@secretkeylabs/xverse-core';
 import { useQuery } from '@tanstack/react-query';
+import useBtcClient from './useBtcClient';
 import useWalletSelector from './useWalletSelector';
 
 const useOrdinalsByAddress = (address: string) => {
   const { network } = useWalletSelector();
+  const btcClient = useBtcClient();
+
   const fetchOrdinals = async (): Promise<BtcOrdinal[]> => {
-    const ordinals = await getOrdinalsByAddress(network.type, address);
+    const ordinals = await getOrdinalsByAddress(btcClient, network.type, address);
     return ordinals.filter((item) => item.id !== undefined);
   };
 

--- a/src/app/hooks/useSendBtcRequest.ts
+++ b/src/app/hooks/useSendBtcRequest.ts
@@ -5,6 +5,7 @@ import { decodeToken } from 'jsontokens';
 import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { SendBtcTransactionOptions } from 'sats-connect';
+import useBtcClient from './useBtcClient';
 import useSeedVault from './useSeedVault';
 import useWalletSelector from './useWalletSelector';
 
@@ -17,6 +18,7 @@ function useSendBtcRequest() {
   const tabId = params.get('tabId') ?? '0';
   const { getSeed } = useSeedVault();
   const { network, selectedAccount } = useWalletSelector();
+  const btcClient = useBtcClient();
 
   const generateSignedTransaction = async () => {
     const seedPhrase = await getSeed();
@@ -34,6 +36,7 @@ function useSendBtcRequest() {
       request.payload?.senderAddress,
       selectedAccount?.id ?? 0,
       seedPhrase,
+      btcClient,
       network.type,
     );
     return signedTx;

--- a/src/app/screens/confirmInscriptionRequest/index.tsx
+++ b/src/app/screens/confirmInscriptionRequest/index.tsx
@@ -213,6 +213,7 @@ function ConfirmInscriptionRequest() {
         btcAddress,
         selectedAccount?.id ?? 0,
         seedPhrase,
+        btcClient,
         network.type,
         new BigNumber(txFee),
       ),

--- a/src/app/screens/createInscription/index.tsx
+++ b/src/app/screens/createInscription/index.tsx
@@ -27,6 +27,7 @@ import ConfirmScreen from '@components/confirmScreen';
 import useWalletSelector from '@hooks/useWalletSelector';
 import { getShortTruncatedAddress } from '@utils/helper';
 
+import useBtcClient from '@hooks/useBtcClient';
 import useSeedVault from '@hooks/useSeedVault';
 import Callout from '@ui-library/callout';
 import { StyledP } from '@ui-library/common.styled';
@@ -267,12 +268,13 @@ function CreateInscription() {
   const [feeRate, setFeeRate] = useState(suggestedMinerFeeRate ?? DEFAULT_FEE_RATE);
   const [feeRates, setFeeRates] = useState<BtcFeeResponse>();
   const { getSeed } = useSeedVault();
+  const btcClient = useBtcClient();
 
   const { ordinalsAddress, network, btcAddress, selectedAccount, btcFiatRate, fiatCurrency } =
     useWalletSelector();
 
   useEffect(() => {
-    getNonOrdinalUtxo(btcAddress, requestedNetwork.type).then(setUtxos);
+    getNonOrdinalUtxo(btcAddress, btcClient, requestedNetwork.type).then(setUtxos);
   }, [btcAddress, requestedNetwork]);
 
   useEffect(() => {

--- a/src/app/screens/ledger/confirmLedgerTransaction/index.tsx
+++ b/src/app/screens/ledger/confirmLedgerTransaction/index.tsx
@@ -107,6 +107,7 @@ function ConfirmLedgerTransaction(): JSX.Element {
     try {
       const result = await signLedgerMixedBtcTransaction({
         transport,
+        esploraProvider: btcClient,
         network: network.type,
         addressIndex,
         recipients: recipients as Recipient[],
@@ -138,6 +139,7 @@ function ConfirmLedgerTransaction(): JSX.Element {
     try {
       const result = await signLedgerNativeSegwitBtcTransaction({
         transport,
+        esploraProvider: btcClient,
         network: network.type,
         addressIndex,
         recipients: recipients as Recipient[],

--- a/src/app/screens/restoreFunds/restoreOrdinals/index.tsx
+++ b/src/app/screens/restoreFunds/restoreOrdinals/index.tsx
@@ -2,6 +2,7 @@ import ActionButton from '@components/button';
 import BottomTabBar from '@components/tabBar';
 import TopRow from '@components/topRow';
 import useOrdinalDataReducer from '@hooks/stores/useOrdinalReducer';
+import useBtcClient from '@hooks/useBtcClient';
 import useOrdinalsByAddress from '@hooks/useOrdinalsByAddress';
 import useSeedVault from '@hooks/useSeedVault';
 import useWalletSelector from '@hooks/useWalletSelector';
@@ -74,6 +75,8 @@ function RestoreOrdinals() {
   const [error, setError] = useState('');
   const [transferringOrdinalId, setTransferringOrdinalId] = useState<string | null>(null);
   const location = useLocation();
+  const btcClient = useBtcClient();
+
   const isRestoreFundFlow = location.state?.isRestoreFundFlow;
 
   const ordinalsUtxos = useMemo(() => ordinals?.map((ord) => ord.utxo), [ordinals]);
@@ -90,6 +93,7 @@ function RestoreOrdinals() {
         btcAddress,
         Number(selectedAccount?.id),
         seedPhrase,
+        btcClient,
         network.type,
         ordinalsUtxos!,
       );

--- a/src/app/screens/sendBrc20/index.tsx
+++ b/src/app/screens/sendBrc20/index.tsx
@@ -1,6 +1,7 @@
 import ActionButton from '@components/button';
 import BottomBar from '@components/tabBar';
 import TopRow from '@components/topRow';
+import useBtcClient from '@hooks/useBtcClient';
 import { useResetUserFlow } from '@hooks/useResetUserFlow';
 import useSeedVault from '@hooks/useSeedVault';
 import useWalletSelector from '@hooks/useWalletSelector';
@@ -62,6 +63,7 @@ function SendBrc20Screen() {
   const [isCreatingOrder, setIsCreatingOrder] = useState(false);
   const [showForm, setShowForm] = useState(false);
   const location = useLocation();
+  const btcClient = useBtcClient();
 
   const coinTicker = location.search ? location.search.split('coinTicker=')[1] : undefined;
   const fungibleToken =
@@ -103,6 +105,7 @@ function SendBrc20Screen() {
         fungibleToken.ticker,
         amountToSend,
         ordinalsAddress,
+        btcClient,
       );
       if ((order.inscriptionRequest as any).error) {
         throw new Error((order.inscriptionRequest as any).error);
@@ -147,6 +150,7 @@ function SendBrc20Screen() {
         btcAddress,
         selectedAccount?.id ?? 0,
         seedPhrase,
+        btcClient,
         network.type,
       );
       navigate('/confirm-inscription-request', {

--- a/src/app/screens/sendBrc20OneStep/index.tsx
+++ b/src/app/screens/sendBrc20OneStep/index.tsx
@@ -1,5 +1,6 @@
 import BottomBar from '@components/tabBar';
 import TopRow from '@components/topRow';
+import useBtcClient from '@hooks/useBtcClient';
 import useBtcFeeRate from '@hooks/useBtcFeeRate';
 import { useResetUserFlow } from '@hooks/useResetUserFlow';
 import useWalletSelector from '@hooks/useWalletSelector';
@@ -35,6 +36,7 @@ function SendBrc20Screen() {
   const [recipientError, setRecipientError] = useState<InputFeedbackProps | null>(null);
   const [recipientAddress, setRecipientAddress] = useState('');
   const [processing, setProcessing] = useState(false);
+  const btcClient = useBtcClient();
 
   useResetUserFlow('/send-brc20');
 
@@ -115,7 +117,7 @@ function SendBrc20Screen() {
       setProcessing(true);
 
       // TODO get this from store or cache?
-      const addressUtxos: UTXO[] = await getNonOrdinalUtxo(btcAddress, network.type);
+      const addressUtxos: UTXO[] = await getNonOrdinalUtxo(btcAddress, btcClient, network.type);
       const ticker = getFtTicker(fungibleToken);
       const numberAmount = Number(replaceCommaByDot(amountToSend));
       const estimateFeesParams: Brc20TransferEstimateFeesParams = {

--- a/src/app/screens/sendBtc/index.tsx
+++ b/src/app/screens/sendBtc/index.tsx
@@ -1,6 +1,7 @@
 import SendForm from '@components/sendForm';
 import BottomBar from '@components/tabBar';
 import TopRow from '@components/topRow';
+import useBtcClient from '@hooks/useBtcClient';
 import { useResetUserFlow } from '@hooks/useResetUserFlow';
 import useSeedVault from '@hooks/useSeedVault';
 import useWalletSelector from '@hooks/useWalletSelector';
@@ -41,6 +42,8 @@ function SendBtcScreen() {
   const { t } = useTranslation('translation', { keyPrefix: 'SEND' });
   const navigate = useNavigate();
   const { getSeed } = useSeedVault();
+  const btcClient = useBtcClient();
+
   const {
     isLoading,
     data,
@@ -60,6 +63,7 @@ function SendBtcScreen() {
         btcAddress,
         selectedAccount?.id ?? 0,
         seedPhrase,
+        btcClient,
         network.type,
       ),
   });

--- a/src/app/screens/sendOrdinal/index.tsx
+++ b/src/app/screens/sendOrdinal/index.tsx
@@ -133,6 +133,7 @@ function SendOrdinal() {
           btcAddress,
           Number(selectedAccount?.id),
           seedPhrase,
+          btcClient,
           network.type,
           [ordUtxo],
         );

--- a/src/app/screens/sendRareSat/index.tsx
+++ b/src/app/screens/sendRareSat/index.tsx
@@ -132,6 +132,7 @@ function SendOrdinal() {
           btcAddress,
           Number(selectedAccount?.id),
           seedPhrase,
+          btcClient,
           network.type,
           [ordUtxo],
         );

--- a/src/app/screens/signPsbtRequest/index.tsx
+++ b/src/app/screens/signPsbtRequest/index.tsx
@@ -122,7 +122,6 @@ function SignPsbtRequest() {
   const [isButtonDisabled, setIsButtonDisabled] = useState(false);
   const [isConnectSuccess, setIsConnectSuccess] = useState(false);
   const [isConnectFailed, setIsConnectFailed] = useState(false);
-  const [isTxApproved, setIsTxApproved] = useState(false);
   const [isTxRejected, setIsTxRejected] = useState(false);
   const { search } = useLocation();
   const params = new URLSearchParams(search);
@@ -277,6 +276,7 @@ function SignPsbtRequest() {
 
     const signingResponse = await signLedgerPSBT({
       transport,
+      esploraProvider: btcClient,
       network: network.type,
       addressIndex,
       psbtInputBase64: psbtBase64,
@@ -461,7 +461,7 @@ function SignPsbtRequest() {
             titleFailed={signatureRequestTranslate('LEDGER.CONFIRM.ERROR_TITLE')}
             textFailed={signatureRequestTranslate('LEDGER.CONFIRM.ERROR_SUBTITLE')}
             imageDefault={ledgerConnectDefaultIcon}
-            isConnectSuccess={isTxApproved}
+            isConnectSuccess={false}
             isConnectFailed={isTxRejected}
           />
         )}


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

- [x] Enhancement

# 📜 Background
We allow the user to change the base Electrs URL that their wallet uses (defaults to mempool.space/api). This was ignored in a variety of core functions which created their own esplora provider instance without considering this URL.

A change was made in Core to have the esplora provider injected into the functions instead of them making the instance themselves. This change required all calls to those functions to inject the esplora provider in the client code, allowing the custom URL to be used.

This will allow people with a lot of UTXOs in their payment address to change the electrs provider and be able to spend their funds.

# 🔄 Changes
The provider is now injected where needed. Before this, changing the URL in settings would still result in the use of mempool.space. This will actualyl change the URL used.

Impact:
The following pages were changed to inject the provider:
- send Btc txn (software and ledger)
- send ordinal (software and ledger) 
- edit fees
- create inscription
- restore ordinal
- send BRC20
- send rare sats
- sign PSBT  (software and ledger)

core pr: https://github.com/secretkeylabs/xverse-core/pull/305

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
