### PR TITLE
revert: check out old component and hack to display v2 bundle data

### DIFF
--- a/src/app/components/rareSatAsset/rareSatAsset.tsx
+++ b/src/app/components/rareSatAsset/rareSatAsset.tsx
@@ -1,0 +1,85 @@
+import RareSatIcon from '@components/rareSatIcon/rareSatIcon';
+import OrdinalImage from '@screens/ordinals/ordinalImage';
+import { Inscription } from '@secretkeylabs/xverse-core';
+import { BundleItem } from '@utils/rareSats';
+import styled from 'styled-components';
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+`;
+
+const InscriptionContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  position: relative;
+  border-radius: 8px;
+  overflow: hidden;
+`;
+
+const RareSatIconContainer = styled.div<{ isGallery: boolean }>((props) => ({
+  display: 'flex',
+  position: 'absolute',
+  zIndex: 1,
+  left: props.isGallery ? 20 : 8,
+  top: props.isGallery ? 20 : 8,
+}));
+
+const RareSatsContainer = styled.div((props) => ({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  width: '100%',
+  aspectRatio: '1',
+  overflow: 'hidden',
+  position: 'relative',
+  backgroundColor: props.theme.colors.elevation1,
+  borderRadius: 8,
+}));
+
+const DynamicSizeContainer = styled.div<{ isCollage: boolean }>((props) => ({
+  width: props.isCollage ? '40%' : '50%',
+  height: props.isCollage ? '40%' : '50%',
+}));
+
+interface Props {
+  item: BundleItem;
+  isCollage?: boolean;
+}
+
+function RareSatAsset({ item, isCollage = false }: Props) {
+  const isGallery: boolean = document.documentElement.clientWidth > 360;
+  const isInscription = item.type === 'inscription' || item.type === 'inscribed-sat';
+
+  return (
+    <Container>
+      {isInscription ? (
+        <InscriptionContainer>
+          {!isCollage && !!item.rarity_ranking && item.rarity_ranking !== 'COMMON' && (
+            <RareSatIconContainer isGallery={isGallery}>
+              <RareSatIcon
+                type={item.rarity_ranking}
+                size={isGallery ? 40 : 24}
+                padding={isGallery ? 8 : 4}
+                bgColor="elevation0"
+              />
+            </RareSatIconContainer>
+          )}
+          <OrdinalImage
+            ordinal={item.inscription as Inscription}
+            isSmallImage={!isGallery && isCollage}
+            withoutSizeIncrease={!isGallery || isCollage}
+          />
+        </InscriptionContainer>
+      ) : (
+        <RareSatsContainer>
+          <DynamicSizeContainer isCollage={isCollage}>
+            <RareSatIcon type={item.rarity_ranking as any} isDynamicSize />
+          </DynamicSizeContainer>
+        </RareSatsContainer>
+      )}
+    </Container>
+  );
+}
+
+export default RareSatAsset;

--- a/src/app/screens/signPsbtRequest/bundleItemsComponent.tsx
+++ b/src/app/screens/signPsbtRequest/bundleItemsComponent.tsx
@@ -1,0 +1,219 @@
+import Eye from '@assets/img/createPassword/Eye.svg';
+import Cross from '@assets/img/dashboard/X.svg';
+import IconOrdinal from '@assets/img/transactions/ordinal.svg';
+import RareSatAsset from '@components/rareSatAsset/rareSatAsset';
+import { animated, useSpring } from '@react-spring/web';
+import { getTruncatedAddress } from '@utils/helper';
+import { BundleItem, getBundleItemSubText } from '@utils/rareSats';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+
+const Container = styled.div((props) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  background: props.theme.colors.elevation1,
+  borderRadius: 12,
+  padding: '16px 16px',
+  justifyContent: 'center',
+  marginBottom: 12,
+}));
+
+const RecipientTitleText = styled.h1((props) => ({
+  ...props.theme.body_medium_m,
+  color: props.theme.colors.white_200,
+  marginBottom: 10,
+}));
+
+const RowContainer = styled.div({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+});
+
+const TransparentButton = styled.button({
+  background: 'transparent',
+  display: 'flex',
+  alignItems: 'center',
+  marginLeft: 10,
+});
+
+const Icon = styled.img((props) => ({
+  marginRight: props.theme.spacing(4),
+  width: 32,
+  height: 32,
+  borderRadius: 30,
+}));
+
+const TitleText = styled.h1((props) => ({
+  ...props.theme.body_medium_m,
+  color: props.theme.colors.white_200,
+}));
+
+const ValueText = styled.h1((props) => ({
+  ...props.theme.body_medium_m,
+  color: props.theme.colors.white_0,
+}));
+
+const SubValueText = styled.h1((props) => ({
+  ...props.theme.body_m,
+  fontSize: 12,
+  color: props.theme.colors.white_400,
+}));
+
+const InscriptionText = styled.h1((props) => ({
+  ...props.theme.body_medium_m,
+  fontSize: 21,
+  marginTop: 24,
+  textAlign: 'center',
+  color: props.theme.colors.white[0],
+  overflowWrap: 'break-word',
+  wordWrap: 'break-word',
+  wordBreak: 'break-word',
+}));
+
+const ColumnContainer = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+  justifyContent: 'flex-end',
+  alignItems: 'flex-end',
+  marginTop: 12,
+});
+
+const CrossContainer = styled.div({
+  display: 'flex',
+  marginTop: 10,
+  justifyContent: 'flex-end',
+  alignItems: 'flex-end',
+});
+
+const OrdinalOuterImageContainer = styled.div({
+  justifyContent: 'center',
+  alignItems: 'center',
+  borderRadius: 2,
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+});
+
+const OrdinalImageContainer = styled.div({
+  width: '50%',
+});
+
+const OrdinalBackgroundContainer = styled(animated.div)({
+  width: '100%',
+  height: '100%',
+  top: 0,
+  left: 0,
+  bottom: 0,
+  right: 0,
+  position: 'fixed',
+  zIndex: 10,
+  background: 'rgba(18, 21, 30, 0.8)',
+  backdropFilter: 'blur(16px)',
+  padding: 16,
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+const EyeIcon = styled.img({
+  width: 20,
+  height: 20,
+});
+
+interface Props {
+  item: BundleItem;
+  userReceivesOrdinal: boolean;
+}
+function BundleItemsComponent({ item, userReceivesOrdinal }: Props) {
+  const { t } = useTranslation('translation');
+  const [showOrdinal, setShowOrdinal] = useState(false);
+  const styles = useSpring({
+    from: {
+      opacity: 0,
+      y: 24,
+    },
+    to: {
+      y: 0,
+      opacity: 1,
+    },
+    delay: 100,
+  });
+  const onButtonClick = () => {
+    setShowOrdinal(true);
+  };
+
+  const onCrossClick = () => {
+    setShowOrdinal(false);
+  };
+  const getItemId = () => {
+    if (item.type === 'inscription') {
+      return item.inscription.id;
+    }
+    if (item.type === 'inscribed-sat' || item.type === 'rare-sat') {
+      return item.number;
+    }
+    return '';
+  };
+  const itemSubText = getBundleItemSubText({
+    satType: item.type,
+    rareSatsType: item.rarity_ranking as any,
+  });
+  const getDetail = () => {
+    if (item.type === 'inscription' || item.type === 'inscribed-sat') {
+      return item.inscription.content_type;
+    }
+    return itemSubText;
+  };
+  const getTitle = () => {
+    if (item.type === 'inscription') {
+      return t('COMMON.INSCRIPTION');
+    }
+    if (item.type === 'inscribed-sat') {
+      return t('RARE_SATS.INSCRIBED_SAT');
+    }
+    return t('RARE_SATS.RARE_SAT');
+  };
+  return (
+    <>
+      {showOrdinal && (
+        <OrdinalBackgroundContainer style={styles}>
+          <CrossContainer onClick={onCrossClick}>
+            <TransparentButton>
+              <img src={Cross} alt="cross" />
+            </TransparentButton>
+          </CrossContainer>
+          <OrdinalOuterImageContainer>
+            <OrdinalImageContainer>
+              <RareSatAsset item={item} />
+            </OrdinalImageContainer>
+            <InscriptionText>{`${getTitle()} ${getItemId()} `}</InscriptionText>
+          </OrdinalOuterImageContainer>
+        </OrdinalBackgroundContainer>
+      )}
+      <Container>
+        <RecipientTitleText>
+          {userReceivesOrdinal
+            ? t('CONFIRM_TRANSACTION.YOU_WILL_RECEIVE')
+            : t('CONFIRM_TRANSACTION.YOU_WILL_TRANSFER')}
+        </RecipientTitleText>
+        <RowContainer>
+          <Icon src={IconOrdinal} />
+          <TitleText>{getTitle()}</TitleText>
+          <ColumnContainer>
+            <RowContainer>
+              <ValueText>{getTruncatedAddress(String(getItemId()))}</ValueText>
+              <TransparentButton onClick={onButtonClick}>
+                <EyeIcon src={Eye} alt="show" />
+              </TransparentButton>
+            </RowContainer>
+            <SubValueText>{getDetail()}</SubValueText>
+          </ColumnContainer>
+        </RowContainer>
+      </Container>
+    </>
+  );
+}
+
+export default BundleItemsComponent;

--- a/src/app/utils/rareSats.ts
+++ b/src/app/utils/rareSats.ts
@@ -73,7 +73,6 @@ export type BundleItem =
 
 // remove later when we fix sign psbt screen
 export const convertV2ToV1Bundle = (v2: any): BundleItem[] => {
-  console.log('v2:', v2);
   const bundleItems: BundleItem[] = [];
   v2.forEach((item) => {
     item.satRanges.forEach((satRange) => {

--- a/src/app/utils/rareSats.ts
+++ b/src/app/utils/rareSats.ts
@@ -41,3 +41,69 @@ export const getSatLabel = (satributes: RareSatsType[]): string => {
     ? `${t('COMMON.COMBO')}`
     : `${getRareSatsLabelByType(satributes[0])} ${getRareSatsLabelByType(satributes[1])}`;
 };
+
+// remove later when we fix sign psbt screen
+export type BundleItem =
+  | {
+      type: 'rare-sat';
+      rarity_ranking: RodarmorRareSatsType;
+      number: string;
+    }
+  | {
+      type: 'inscribed-sat';
+      rarity_ranking: RodarmorRareSatsType;
+      number: string;
+      inscription: {
+        id: string;
+        content_type: string;
+      };
+    }
+  | {
+      type: 'inscription';
+      rarity_ranking: RodarmorRareSatsType;
+      inscription: {
+        id: string;
+        content_type: string;
+      };
+    }
+  | {
+      type: 'unknown';
+      rarity_ranking: 'unknown';
+    };
+
+// remove later when we fix sign psbt screen
+export const convertV2ToV1Bundle = (v2: any): BundleItem[] => {
+  console.log('v2:', v2);
+  const bundleItems: BundleItem[] = [];
+  v2.forEach((item) => {
+    item.satRanges.forEach((satRange) => {
+      satRange.inscriptions.forEach((inscription) => {
+        bundleItems.push({
+          type: 'inscription',
+          rarity_ranking: 'COMMON',
+          inscription,
+        });
+      });
+    });
+  });
+  return bundleItems;
+};
+
+// remove later when we fix sign psbt screen
+export const getBundleItemSubText = ({
+  satType,
+  rareSatsType,
+}: {
+  satType: any;
+  rareSatsType: RareSatsType;
+}) =>
+  ({
+    inscription: t('COMMON.INSCRIPTION'),
+    'rare-sat': t('RARE_SATS.SAT_TYPES.RARE_SAT', {
+      type: getRareSatsLabelByType(rareSatsType ?? 'unknown'),
+    }),
+    'inscribed-sat': t('RARE_SATS.SAT_TYPES.INSCRIBED_RARE_SAT', {
+      type: getRareSatsLabelByType(rareSatsType ?? 'unknown'),
+    }),
+    unknown: t('RARE_SATS.SAT_TYPES.UNKNOWN_RARE_SAT'),
+  }[satType]);


### PR DESCRIPTION
remember to revert this when working on sign psbt screen v2

# 🔘 PR Type
- [ ] Bugfix
- [x] Other... Please describe: half revert, with new method to convert v2 data to v1

# 📜 Background
Provide a brief explanation of why this pull request is needed. Include the problem you are solving or the functionality you are adding. Reference any related issues.

https://linear.app/xverseapp/issue/ENG-3392/[satr-ext-12]-see-sent-and-received-rare-sats-in-psbt-signing-tx#comment-eed4c5cb

# 🔄 Changes
- reverted the sign psbt file to not display the new Sat bundle UI
- checked out old copies of UI components
- added back missing functions in utils/rare sats and created a quick conversion function

Impact:
- sign psbt screen only

# 🖼 Screenshot / 📹 Video
Include screenshots or a video demonstrating the changes. This is especially helpful for UI changes.

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
