### PR TITLE
[ENG-3427] fix: allow-404-get-utxos-from-psbt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ledgerhq/hw-transport-webusb": "^6.27.13",
         "@phosphor-icons/react": "^2.0.10",
         "@react-spring/web": "^9.6.1",
-        "@secretkeylabs/xverse-core": "5.2.0-1489894",
+        "@secretkeylabs/xverse-core": "5.3.0",
         "@stacks/connect": "^6.10.2",
         "@stacks/encryption": "4.3.5",
         "@stacks/stacks-blockchain-api-types": "6.1.1",
@@ -1727,9 +1727,9 @@
       }
     },
     "node_modules/@secretkeylabs/xverse-core": {
-      "version": "5.2.0-1489894",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/5.2.0-1489894/ec450fefb437094b01a9cfc94fbbaa6bbbb4ae66",
-      "integrity": "sha512-0DBAC+ShYdQr/pLV2aUUsUHor3XHkxZ2lspFOwaHW0ALU4sdkgjO9nSixbVLankKayO+/yRUruT0j3fNipnDVQ==",
+      "version": "5.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/5.3.0/368b6b101c6dd5d67497dc047a6305afe3812af3",
+      "integrity": "sha512-cVJJmDgT6d1urtYFugfo7MAHPLmqyk8kO2s81x/KFQhgU6kqhhfu2Oeu71lAAxRc71jvzCYtxF20zj+P6bqEgw==",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
@@ -16040,9 +16040,9 @@
       }
     },
     "@secretkeylabs/xverse-core": {
-      "version": "5.2.0-1489894",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/5.2.0-1489894/ec450fefb437094b01a9cfc94fbbaa6bbbb4ae66",
-      "integrity": "sha512-0DBAC+ShYdQr/pLV2aUUsUHor3XHkxZ2lspFOwaHW0ALU4sdkgjO9nSixbVLankKayO+/yRUruT0j3fNipnDVQ==",
+      "version": "5.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/5.3.0/368b6b101c6dd5d67497dc047a6305afe3812af3",
+      "integrity": "sha512-cVJJmDgT6d1urtYFugfo7MAHPLmqyk8kO2s81x/KFQhgU6kqhhfu2Oeu71lAAxRc71jvzCYtxF20zj+P6bqEgw==",
       "requires": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
         "@noble/secp256k1": "^1.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ledgerhq/hw-transport-webusb": "^6.27.13",
         "@phosphor-icons/react": "^2.0.10",
         "@react-spring/web": "^9.6.1",
-        "@secretkeylabs/xverse-core": "5.2.0",
+        "@secretkeylabs/xverse-core": "5.2.0-1489894",
         "@stacks/connect": "^6.10.2",
         "@stacks/encryption": "4.3.5",
         "@stacks/stacks-blockchain-api-types": "6.1.1",
@@ -1727,9 +1727,9 @@
       }
     },
     "node_modules/@secretkeylabs/xverse-core": {
-      "version": "5.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/5.2.0/f4d46eacac2b7be0b6fb70ce5184d1c10ed7bfa6",
-      "integrity": "sha512-DhDrTAFYPHf22ThYn+z9DIlxXN6M7jH5JEbAi5I58xE62RsEOcpxfRHDhfNzcNAyWKJEXzChkbOp7OpFHLIF1w==",
+      "version": "5.2.0-1489894",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/5.2.0-1489894/ec450fefb437094b01a9cfc94fbbaa6bbbb4ae66",
+      "integrity": "sha512-0DBAC+ShYdQr/pLV2aUUsUHor3XHkxZ2lspFOwaHW0ALU4sdkgjO9nSixbVLankKayO+/yRUruT0j3fNipnDVQ==",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
@@ -1743,7 +1743,7 @@
         "@stacks/transactions": "4.3.5",
         "@stacks/wallet-sdk": "^5.0.2",
         "@zondax/ledger-stacks": "^1.0.4",
-        "axios": "0.27.2",
+        "axios": "1.4.0",
         "base64url": "^3.0.1",
         "bip32": "^4.0.0",
         "bip39": "3.0.3",
@@ -1762,6 +1762,9 @@
         "util": "^0.12.4",
         "uuidv4": "^6.2.13",
         "varuint-bitcoin": "^1.1.2"
+      },
+      "engines": {
+        "node": "^18.18.2"
       },
       "peerDependencies": {
         "bignumber.js": "^9.0.0",
@@ -1891,15 +1894,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/@secretkeylabs/xverse-core/node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
       }
     },
     "node_modules/@secretkeylabs/xverse-core/node_modules/base-x": {
@@ -16046,9 +16040,9 @@
       }
     },
     "@secretkeylabs/xverse-core": {
-      "version": "5.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/5.2.0/f4d46eacac2b7be0b6fb70ce5184d1c10ed7bfa6",
-      "integrity": "sha512-DhDrTAFYPHf22ThYn+z9DIlxXN6M7jH5JEbAi5I58xE62RsEOcpxfRHDhfNzcNAyWKJEXzChkbOp7OpFHLIF1w==",
+      "version": "5.2.0-1489894",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/5.2.0-1489894/ec450fefb437094b01a9cfc94fbbaa6bbbb4ae66",
+      "integrity": "sha512-0DBAC+ShYdQr/pLV2aUUsUHor3XHkxZ2lspFOwaHW0ALU4sdkgjO9nSixbVLankKayO+/yRUruT0j3fNipnDVQ==",
       "requires": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
         "@noble/secp256k1": "^1.7.1",
@@ -16061,7 +16055,7 @@
         "@stacks/transactions": "4.3.5",
         "@stacks/wallet-sdk": "^5.0.2",
         "@zondax/ledger-stacks": "^1.0.4",
-        "axios": "0.27.2",
+        "axios": "1.4.0",
         "base64url": "^3.0.1",
         "bip32": "^4.0.0",
         "bip39": "3.0.3",
@@ -16182,15 +16176,6 @@
                 }
               }
             }
-          }
-        },
-        "axios": {
-          "version": "0.27.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-          "requires": {
-            "follow-redirects": "^1.14.9",
-            "form-data": "^4.0.0"
           }
         },
         "base-x": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@ledgerhq/hw-transport-webusb": "^6.27.13",
     "@phosphor-icons/react": "^2.0.10",
     "@react-spring/web": "^9.6.1",
-    "@secretkeylabs/xverse-core": "5.2.0",
+    "@secretkeylabs/xverse-core": "5.2.0-1489894",
     "@stacks/connect": "^6.10.2",
     "@stacks/encryption": "4.3.5",
     "@stacks/stacks-blockchain-api-types": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@ledgerhq/hw-transport-webusb": "^6.27.13",
     "@phosphor-icons/react": "^2.0.10",
     "@react-spring/web": "^9.6.1",
-    "@secretkeylabs/xverse-core": "5.2.0-1489894",
+    "@secretkeylabs/xverse-core": "5.3.0",
     "@stacks/connect": "^6.10.2",
     "@stacks/encryption": "4.3.5",
     "@stacks/stacks-blockchain-api-types": "6.1.1",

--- a/src/app/hooks/useDetectOrdinalInSignPsbt.ts
+++ b/src/app/hooks/useDetectOrdinalInSignPsbt.ts
@@ -1,10 +1,9 @@
 import {
   Bundle,
-  getUtxoOrdinalBundle,
+  getUtxoOrdinalBundleIfFound,
   mapRareSatsAPIResponseToBundle,
   ParsedPSBT,
 } from '@secretkeylabs/xverse-core';
-import { isAxiosError } from 'axios';
 import useWalletSelector from './useWalletSelector';
 
 export type InputsBundle = (Pick<Bundle, 'satRanges' | 'totalExoticSats'> & {
@@ -22,15 +21,7 @@ const useDetectOrdinalInSignPsbt = () => {
 
     if (parsedPsbt) {
       const inputsRequest = parsedPsbt.inputs.map((input) =>
-        getUtxoOrdinalBundle(network.type, input.txid, input.index).catch((e) => {
-          // we don't reject on 404s because if the UTXO is not found,
-          // it is likely this is a UTXO from an unpublished txn.
-          // this is required for gamma.io purchase flow
-          if (!isAxiosError(e) || e.response?.status !== 404) {
-            // rethrow error if response was not 404
-            throw e;
-          }
-        }),
+        getUtxoOrdinalBundleIfFound(network.type, input.txid, input.index),
       );
       const inputsResponse = await Promise.all(inputsRequest);
       inputsResponse.forEach((inputResponse, index) => {


### PR DESCRIPTION
# 🔘 PR Type
- [x] Bugfix

# 📜 Background
https://linear.app/xverseapp/issue/ENG-3427

depends on https://github.com/secretkeylabs/xverse-core/pull/317

# 🔄 Changes
- fix: handle 404s from the get ordinals in utxo endpoint when detecting for the sign psbt screen

Impact:
- sign psbt screen only

# 🖼 Screenshot / 📹 Video
with fix:
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/31c42508-e2c1-4218-8c61-f11ee236cc5c)


# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.