### PR TITLE
Fix account referencing issue on login

### DIFF
--- a/src/app/components/guards/auth.tsx
+++ b/src/app/components/guards/auth.tsx
@@ -1,13 +1,13 @@
-import { PropsWithChildren, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import useSeedVault from '@hooks/useSeedVault';
 import useWalletSelector from '@hooks/useWalletSelector';
-import { useDispatch } from 'react-redux';
 import { setWalletUnlockedAction } from '@stores/wallet/actions/actionCreators';
+import { PropsWithChildren, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 
 function AuthGuard({ children }: PropsWithChildren) {
   const navigate = useNavigate();
-  const { masterPubKey, encryptedSeed, isUnlocked } = useWalletSelector();
+  const { masterPubKey, encryptedSeed, isUnlocked, accountsList } = useWalletSelector();
   const { getSeed, hasSeed } = useSeedVault();
   const dispatch = useDispatch();
 
@@ -26,7 +26,12 @@ function AuthGuard({ children }: PropsWithChildren) {
       return;
     }
     const hasSeedPhrase = await hasSeed();
-    if (!hasSeedPhrase || !masterPubKey) {
+    if (
+      !hasSeedPhrase ||
+      // We ensure there is at least 1 account with a masterPubKey as the unlock code will select an account if one
+      // is not selected in the store
+      (!masterPubKey && (accountsList.length === 0 || !accountsList[0].masterPubKey))
+    ) {
       navigate('/landing');
       return;
     }

--- a/src/app/hooks/useWalletReducer.ts
+++ b/src/app/hooks/useWalletReducer.ts
@@ -332,36 +332,24 @@ const useWalletReducer = () => {
   };
 
   const addLedgerAccount = async (ledgerAccount: Account) => {
-    try {
-      dispatch(updateLedgerAccountsAction([...ledgerAccountsList, ledgerAccount]));
-    } catch (err) {
-      return Promise.reject(err);
-    }
+    dispatch(updateLedgerAccountsAction([...ledgerAccountsList, ledgerAccount]));
   };
 
   const removeLedgerAccount = async (ledgerAccount: Account) => {
-    try {
-      dispatch(
-        updateLedgerAccountsAction(
-          ledgerAccountsList.filter((account) => account.id !== ledgerAccount.id),
-        ),
-      );
-    } catch (err) {
-      return Promise.reject(err);
-    }
+    dispatch(
+      updateLedgerAccountsAction(
+        ledgerAccountsList.filter((account) => account.id !== ledgerAccount.id),
+      ),
+    );
   };
 
   const updateLedgerAccounts = async (updatedLedgerAccount: Account) => {
     const newLedgerAccountsList = ledgerAccountsList.map((account) =>
       account.id === updatedLedgerAccount.id ? updatedLedgerAccount : account,
     );
-    try {
-      dispatch(updateLedgerAccountsAction(newLedgerAccountsList));
-      if (isLedgerAccount(selectedAccount) && updatedLedgerAccount.id === selectedAccount?.id) {
-        switchAccount(updatedLedgerAccount);
-      }
-    } catch (err) {
-      return Promise.reject(err);
+    dispatch(updateLedgerAccountsAction(newLedgerAccountsList));
+    if (isLedgerAccount(selectedAccount) && updatedLedgerAccount.id === selectedAccount?.id) {
+      switchAccount(updatedLedgerAccount);
     }
   };
 

--- a/src/app/hooks/useWalletReducer.ts
+++ b/src/app/hooks/useWalletReducer.ts
@@ -65,6 +65,7 @@ const useWalletReducer = () => {
       currentAccounts,
     );
 
+    // we sanitise the account to remove any unknown properties which we had in pervious versions of the app
     walletAccounts[0] = {
       id: walletAccounts[0].id,
       btcAddress: walletAccounts[0].btcAddress,
@@ -77,13 +78,18 @@ const useWalletReducer = () => {
       bnsName: walletAccounts[0].bnsName,
     };
 
-    let selectedAccountData: Account;
+    let selectedAccountData: Account | undefined;
     if (!selectedAccount) {
       [selectedAccountData] = walletAccounts;
     } else if (isLedgerAccount(selectedAccount)) {
-      selectedAccountData = ledgerAccountsList[selectedAccount.id];
+      selectedAccountData = ledgerAccountsList.find((a) => a.id === selectedAccount.id);
     } else {
-      selectedAccountData = walletAccounts[selectedAccount.id];
+      selectedAccountData = walletAccounts.find((a) => a.id === selectedAccount.id);
+    }
+
+    if (!selectedAccountData) {
+      // this should not happen but is a good fallback to have, just in case
+      [selectedAccountData] = walletAccounts;
     }
 
     if (!isHardwareAccount(selectedAccountData)) {


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background
On login we were using the account id as an index of the account list, which broke when the deletion of Ledger accounts was added.

# 🔄 Changes
We now reference the accounts by ID.

To reproduce on develop branch:
- Create 2 ledger accounts
- Delete the first one
- Switch to the one that's left
- Lock your wallet
- Unlock with password
- Wallet should be a bit broken at this stage
- Lock your wallet
- Close the popup and open again and you should be met with the onboarding screen

This should work fine on this branch

Should also test:
- onboarding flow
- login flow

# 🖼 Screenshot / 📹 Video
Include screenshots or a video demonstrating the changes. This is especially helpful for UI changes.

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
