### PR TITLE
[ENG-3325] chore: refactor workflows

### DIFF
--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -17,8 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           always-auth: true
           node-version: 18
@@ -82,7 +81,7 @@ jobs:
           echo "FILENAME=xverse-web-extension.$NEXT_TAG.zip" >> $GITHUB_OUTPUT
           echo "UPLOAD_URL=$(cat release.json | jq -r .upload_url)" >> $GITHUB_OUTPUT
       - id: update-description
-        name: Update description with release notes
+        name: Update PR description with release notes
         env:
           PR_ID: ${{ github.event.pull_request.number }}
         run: |

--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -21,9 +21,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           always-auth: true
-          node-version: '18.x'
+          node-version: 18
           registry-url: https://npm.pkg.github.com
           scope: '@secretkeylabs'
+          cache: npm
       - name: Install dependencies
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGE_REGISTRY_TOKEN }}
@@ -42,16 +43,16 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
     outputs:
       upload_url: ${{ steps.publish-prerelease.outputs.UPLOAD_URL }}
       filename: ${{ steps.publish-prerelease.outputs.FILENAME }}
     steps:
       - uses: actions/checkout@v4
       - id: publish-prerelease
-        name: Publish prerelease
+        name: Publish release candidate as prerelease
         env:
-          GH_TOKEN: ${{ github.token }}
-          PR_ID: ${{ github.event.pull_request.number }}
           SOURCE_BRANCH: ${{ github.head_ref }}
           TARGET_COMMITISH: ${{ github.event.pull_request.head.sha }}
         run: |
@@ -60,8 +61,11 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/{owner}/{repo}/releases > releases.json
+          # get $TAG from branch name, e.g. v0.25.0
           TAG=$(echo $SOURCE_BRANCH | sed 's/release\/\(.*\)/\1/')
-          ./find-tag.sh # look up releases.json and export $NEXT_TAG
+          # export $NEXT_TAG using releases.json and $TAG, e.g. v0.25.0-rc.0
+          cd scripts
+          ./find-tag.sh
           # publish the release as prerelease rc
           gh api \
             --method POST \
@@ -74,6 +78,14 @@ jobs:
             -F draft=false \
             -F prerelease=true \
             -F generate_release_notes=true > release.json
+          # save output for upload
+          echo "FILENAME=xverse-web-extension.$NEXT_TAG.zip" >> $GITHUB_OUTPUT
+          echo "UPLOAD_URL=$(cat release.json | jq -r .upload_url)" >> $GITHUB_OUTPUT
+      - id: update-description
+        name: Update description with release notes
+        env:
+          PR_ID: ${{ github.event.pull_request.number }}
+        run: |
           # update PR description
           cat release.json | jq -r .body > body.md
           echo -e "\n\nRelease candidate: $(cat release.json | jq -r .html_url)" >> body.md
@@ -84,35 +96,31 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/{owner}/{repo}/pulls/$PR_ID \
             -F 'body=@body.md'
-          # save output for upload
-          echo "FILENAME=xverse-web-extension.$NEXT_TAG.zip" >> $GITHUB_OUTPUT
-          echo "UPLOAD_URL=$(cat release.json | jq -r .upload_url)" >> $GITHUB_OUTPUT
   build-rc:
     needs: publish-rc
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           always-auth: true
-          node-version: '18.x'
+          node-version: 18
           registry-url: https://npm.pkg.github.com
           scope: '@secretkeylabs'
+          cache: npm
       - name: Install dependencies
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGE_REGISTRY_TOKEN }}
         run: npm ci
-      - name: Build
+      - name: Build & zip
         env:
           TRANSAC_API_KEY: ${{ secrets.TRANSAC_API_KEY }}
           MOON_PAY_API_KEY: ${{ secrets.MOON_PAY_API_KEY }}
           MIX_PANEL_TOKEN: ${{ secrets.MIX_PANEL_TOKEN }}
-        run: npm run build --if-present
-      - name: Create Archive
         run: |
+          npm run build
           zip -rj build.zip ./build
-      - name: Upload Release Asset
+      - name: Upload release asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -1,9 +1,4 @@
 name: Build & Publish Release Candidate
-
-on:
-  pull_request:
-    branches: [main, develop]
-
 ##
 # This workflow builds new release candidates (create release + upload asset):
 # - for a new release PR and
@@ -11,6 +6,11 @@ on:
 #
 # It should also keep the release PR description in sync with the latest release candidate
 #
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
 jobs:
   test:
     if: ${{ startsWith(github.head_ref, 'release/') }}

--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -1,4 +1,4 @@
-name: Build & Publish Release Candidate
+name: Build & Publish release candidate
 ##
 # This workflow builds new release candidates (create release + upload asset):
 # - for a new release PR and

--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -1,0 +1,124 @@
+name: Build & Publish Release Candidate
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+##
+# This workflow builds new release candidates (create release + upload asset):
+# - for a new release PR and
+# - for every push to the release PR head branch
+#
+# It should also keep the release PR description in sync with the latest release candidate
+#
+jobs:
+  test:
+    if: ${{ startsWith(github.head_ref, 'release/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          always-auth: true
+          node-version: '18.x'
+          registry-url: https://npm.pkg.github.com
+          scope: '@secretkeylabs'
+      - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGE_REGISTRY_TOKEN }}
+        run: npm ci
+      - name: Test
+        run: |
+          npx eslint .
+          npx tsc --noEmit
+          npm test
+  publish-rc:
+    # TODO also keep the develop PR description up to date
+    if: ${{ github.base_ref == 'main' }}
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    outputs:
+      upload_url: ${{ steps.publish-prerelease.outputs.UPLOAD_URL }}
+      filename: ${{ steps.publish-prerelease.outputs.FILENAME }}
+    steps:
+      - id: publish-prerelease
+        name: Publish prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_ID: ${{ github.event.pull_request.number }}
+          SOURCE_BRANCH: ${{ github.head_ref }}
+          TARGET_COMMITISH: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # find the next rc tag
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/{owner}/{repo}/releases > releases.json
+          TAG=$(echo $SOURCE_BRANCH | sed 's/release\/\(.*\)/\1/')
+          ./find-tag.sh # look up releases.json and export $NEXT_TAG
+          # publish the release as prerelease rc
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/{owner}/{repo}/releases \
+            -f tag_name="$NEXT_TAG" \
+            -f target_commitish="$TARGET_COMMITISH" \
+            -f name="$NEXT_TAG" \
+            -F draft=false \
+            -F prerelease=true \
+            -F generate_release_notes=true > release.json
+          # update PR description
+          cat release.json | jq -r .body > body.md
+          echo -e "\n\nRelease candidate: $(cat release.json | jq -r .html_url)" >> body.md
+          echo -e "\nTo publish this rc as latest: Merge Commit this PR" >> body.md
+          gh api \
+            --method PATCH \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/{owner}/{repo}/pulls/$PR_ID \
+            -F 'body=@body.md'
+          # save output for upload
+          echo "FILENAME=xverse-web-extension.$NEXT_TAG.zip" >> $GITHUB_OUTPUT
+          echo "UPLOAD_URL=$(cat release.json | jq -r .upload_url)" >> $GITHUB_OUTPUT
+  build-rc:
+    needs: publish-rc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          always-auth: true
+          node-version: '18.x'
+          registry-url: https://npm.pkg.github.com
+          scope: '@secretkeylabs'
+      - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGE_REGISTRY_TOKEN }}
+        run: npm ci
+      - name: Build
+        env:
+          TRANSAC_API_KEY: ${{ secrets.TRANSAC_API_KEY }}
+          MOON_PAY_API_KEY: ${{ secrets.MOON_PAY_API_KEY }}
+          MIX_PANEL_TOKEN: ${{ secrets.MIX_PANEL_TOKEN }}
+        run: npm run build --if-present
+      - name: Create Archive
+        run: |
+          zip -rj build.zip ./build
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPLOAD_URL: ${{needs.publish-rc.outputs.upload_url}}
+          FILENAME: ${{needs.publish-rc.outputs.filename}}
+        with:
+          upload_url: $UPLOAD_URL
+          asset_path: build.zip
+          asset_name: $FILENAME
+          asset_content_type: application/zip

--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -46,6 +46,7 @@ jobs:
       upload_url: ${{ steps.publish-prerelease.outputs.UPLOAD_URL }}
       filename: ${{ steps.publish-prerelease.outputs.FILENAME }}
     steps:
+      - uses: actions/checkout@v4
       - id: publish-prerelease
         name: Publish prerelease
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,6 @@ jobs:
           npx eslint .
           npx tsc --noEmit
           npm test
-      - name: Install dependencies
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGE_REGISTRY_TOKEN }}
-        run: npm ci
       - name: Build
         env:
           TRANSAC_API_KEY: ${{ secrets.TRANSAC_API_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,11 @@
-name: Build & Publish Release Candidates
+name: Build for PR
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [develop]
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,105 +25,6 @@ jobs:
           npx eslint .
           npx tsc --noEmit
           npm test
-  publish-github-release-candidate:
-    if: ${{ github.base_ref == 'main' && startsWith(github.head_ref, 'release/')}}
-    needs: test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-    outputs:
-      upload_url: ${{ steps.publish-prerelease-rc.outputs.UPLOAD_URL }}
-      filename: ${{ steps.publish-prerelease-rc.outputs.FILENAME }}
-    steps:
-      - id: publish-prerelease-rc
-        name: Publish prerelease rc
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_ID: ${{ github.event.pull_request.number }}
-          SOURCE_BRANCH: ${{ github.head_ref }}
-        run: |
-          # find the next rc tag
-          gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/{owner}/{repo}/releases > releases.json
-          TAG=$(echo $SOURCE_BRANCH | sed 's/release\/\(.*\)/\1/')
-          ./find-tag.sh # look up releases.json and export $NEXT_TAG
-          # publish the github release
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/{owner}/{repo}/releases \
-            -f tag_name="$NEXT_TAG" \
-            -f target_commitish="$SOURCE_BRANCH" \
-            -f name="$NEXT_TAG" \
-            -F draft=false \
-            -F prerelease=true \
-            -F generate_release_notes=true > release.json
-          # update PR description
-          cat release.json | jq -r .body > body.md
-          echo -e "\n\nRelease candidate: $(cat release.json | jq -r .html_url)" >> body.md
-          echo -e "\nTo publish a latest release: Merge Commit this PR" >> body.md
-          gh api \
-            --method PATCH \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/{owner}/{repo}/pulls/$PR_ID \
-            -F 'body=@body.md'
-          echo "FILENAME=xverse-web-extension.$NEXT_TAG.zip" >> $GITHUB_OUTPUT
-          echo "UPLOAD_URL=$(cat release.json | jq -r .upload_url)" >> $GITHUB_OUTPUT
-  build-for-release-candidate:
-    needs: publish-github-release-candidate
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          always-auth: true
-          node-version: '18.x'
-          registry-url: https://npm.pkg.github.com
-          scope: '@secretkeylabs'
-      - name: Install dependencies
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGE_REGISTRY_TOKEN }}
-        run: npm ci
-      - name: Build
-        env:
-          TRANSAC_API_KEY: ${{ secrets.TRANSAC_API_KEY }}
-          MOON_PAY_API_KEY: ${{ secrets.MOON_PAY_API_KEY }}
-          MIX_PANEL_TOKEN: ${{ secrets.MIX_PANEL_TOKEN }}
-        run: npm run build --if-present
-      - name: Create Archive
-        run: |
-          zip -rj build.zip ./build
-      - name: Upload Release Asset
-        if: ${{ github.event.release.upload_url }}
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          UPLOAD_URL: ${{needs.publish-github-release-candidate.outputs.upload_url}}
-          FILENAME: ${{needs.publish-github-release-candidate.outputs.filename}}
-        with:
-          upload_url: $UPLOAD_URL
-          asset_path: build.zip
-          asset_name: $FILENAME
-          asset_content_type: application/zip
-  build-for-pr:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          always-auth: true
-          node-version: '18.x'
-          registry-url: https://npm.pkg.github.com
-          scope: '@secretkeylabs'
       - name: Install dependencies
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGE_REGISTRY_TOKEN }}
@@ -147,7 +48,7 @@ jobs:
           retention-days: 30
           if-no-files-found: error
   comment-on-pr:
-    needs: build-for-pr
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,11 @@
-name: Build
+name: Build & Publish Release Candidates
 
 on:
   pull_request:
     branches: [main, develop]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,6 +25,109 @@ jobs:
           npx eslint .
           npx tsc --noEmit
           npm test
+  publish-github-release-candidate:
+    if: ${{ github.base_ref == 'main' && startsWith(github.head_ref, 'release/')}}
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    outputs:
+      upload_url: ${{ steps.publish-prerelease-rc.outputs.UPLOAD_URL }}
+      filename: ${{ steps.publish-prerelease-rc.outputs.FILENAME }}
+    steps:
+      - id: publish-prerelease-rc
+        name: Publish prerelease rc
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_ID: ${{ github.event.pull_request.number }}
+          SOURCE_BRANCH: ${{ github.head_ref }}
+        run: |
+          # find the next rc tag
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/{owner}/{repo}/releases > releases.json
+          TAG=$(echo $SOURCE_BRANCH | sed 's/release\/\(.*\)/\1/')
+          ./find-tag.sh # look up releases.json and export $NEXT_TAG
+          # publish the github release
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/{owner}/{repo}/releases \
+            -f tag_name="$NEXT_TAG" \
+            -f target_commitish="$SOURCE_BRANCH" \
+            -f name="$NEXT_TAG" \
+            -F draft=false \
+            -F prerelease=true \
+            -F generate_release_notes=true > release.json
+          # update PR description
+          cat release.json | jq -r .body > body.md
+          echo -e "\n\nRelease candidate: $(cat release.json | jq -r .html_url)" >> body.md
+          echo -e "\nTo publish a latest release: Merge Commit this PR" >> body.md
+          gh api \
+            --method PATCH \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/{owner}/{repo}/pulls/$PR_ID \
+            -F 'body=@body.md'
+          echo "FILENAME=xverse-web-extension.$NEXT_TAG.zip" >> $GITHUB_OUTPUT
+          echo "UPLOAD_URL=$(cat release.json | jq -r .upload_url)" >> $GITHUB_OUTPUT
+  build-for-release-candidate:
+    needs: publish-github-release-candidate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          always-auth: true
+          node-version: '18.x'
+          registry-url: https://npm.pkg.github.com
+          scope: '@secretkeylabs'
+      - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGE_REGISTRY_TOKEN }}
+        run: npm ci
+      - name: Build
+        env:
+          TRANSAC_API_KEY: ${{ secrets.TRANSAC_API_KEY }}
+          MOON_PAY_API_KEY: ${{ secrets.MOON_PAY_API_KEY }}
+          MIX_PANEL_TOKEN: ${{ secrets.MIX_PANEL_TOKEN }}
+        run: npm run build --if-present
+      - name: Create Archive
+        run: |
+          zip -rj build.zip ./build
+      - name: Upload Release Asset
+        if: ${{ github.event.release.upload_url }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPLOAD_URL: ${{needs.publish-github-release-candidate.outputs.upload_url}}
+          FILENAME: ${{needs.publish-github-release-candidate.outputs.filename}}
+        with:
+          upload_url: $UPLOAD_URL
+          asset_path: build.zip
+          asset_name: $FILENAME
+          asset_content_type: application/zip
+  build-for-pr:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          always-auth: true
+          node-version: '18.x'
+          registry-url: https://npm.pkg.github.com
+          scope: '@secretkeylabs'
+      - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGE_REGISTRY_TOKEN }}
+        run: npm ci
       - name: Build
         env:
           TRANSAC_API_KEY: ${{ secrets.TRANSAC_API_KEY }}
@@ -44,7 +147,7 @@ jobs:
           retention-days: 30
           if-no-files-found: error
   comment-on-pr:
-    needs: build
+    needs: build-for-pr
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -83,48 +186,3 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/{owner}/{repo}/issues/$PR_ID/comments \
             -f body="Test with build here: $ARTIFACT_URL"
-  publish-github-release-candidate:
-    if: ${{ github.base_ref == 'main' && startsWith(github.head_ref, 'release/')}}
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-    steps:
-      - id: publish-prerelease-rc
-        name: Publish prerelease rc
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_ID: ${{ github.event.pull_request.number }}
-          SOURCE_BRANCH: ${{ github.head_ref }}
-        run: |
-          # find the next rc tag
-          gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/{owner}/{repo}/releases > releases.json
-          TAG=$(echo $SOURCE_BRANCH | sed 's/release\/\(.*\)/\1/')
-          ./find-tag.sh # look up releases.json and export $NEXT_TAG
-          # publish the github release
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/{owner}/{repo}/releases \
-            -f tag_name="$NEXT_TAG" \
-            -f target_commitish="$SOURCE_BRANCH" \
-            -f name="$NEXT_TAG" \
-            -F draft=false \
-            -F prerelease=true \
-            -F generate_release_notes=true > release.json
-          # update PR description
-          cat release.json | jq -r .body > body.md
-          echo -e "\n\nRelease candidate: $(cat release.json | jq -r .html_url)" >> body.md
-          echo -e "\nTo publish a latest release: Merge Commit this PR" >> body.md
-          gh api \
-            --method PATCH \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/{owner}/{repo}/pulls/$PR_ID \
-            -F 'body=@body.md'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,16 +1,16 @@
 name: Build for PR
-
-on:
-  pull_request:
-    branches: [develop]
-
 ##
 # This workflow tests, builds, and uploads the extension code for each PR
 #
 # It should also keep an updated comment on the PR showing where the upload is
 #
+on:
+  pull_request:
+    branches:
+      - develop
 jobs:
   build:
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,9 +18,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           always-auth: true
-          node-version: '18.x'
+          node-version: 18
           registry-url: https://npm.pkg.github.com
           scope: '@secretkeylabs'
+          cache: npm
       - name: Install dependencies
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGE_REGISTRY_TOKEN }}
@@ -39,7 +40,7 @@ jobs:
       - name: Save Filename
         run: |
           BRANCH_NAME=$(echo ${{ github.head_ref }} | sed 's/\//-/g')
-          GIT_SHA_SHORT=$(git rev-parse --short ${{ github.sha }})
+          GIT_SHA_SHORT=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})
           echo "FILENAME=xverse-extension.$BRANCH_NAME.$GIT_SHA_SHORT" >> $GITHUB_ENV
       - name: Upload Archive
         uses: actions/upload-artifact@v3
@@ -54,9 +55,11 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
-      - name: Get Artifact URL
+      - name: Get artifact URL
         env:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
@@ -65,8 +68,6 @@ jobs:
           ARTIFACT_URL="https://github.com/$OWNER/$REPO/actions/runs/$WORKFLOW_ID"
           echo "ARTIFACT_URL=$ARTIFACT_URL" >> $GITHUB_ENV
       - name: Delete old bot comments
-        env:
-          GH_TOKEN: ${{ github.token }}
           PR_ID: ${{ github.event.pull_request.number }}
         run: |
           gh api \
@@ -81,7 +82,6 @@ jobs:
             /repos/{owner}/{repo}/issues/comments/%q
       - name: Post test package PR comment
         env:
-          GH_TOKEN: ${{ github.token }}
           PR_ID: ${{ github.event.pull_request.number }}
         run: |
           gh api \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [develop]
 
+##
+# This workflow tests, builds, and uploads the extension code for each PR
+#
+# It should also keep an updated comment on the PR showing where the upload is
+#
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -59,7 +64,6 @@ jobs:
           ARTIFACT_URL="https://github.com/$OWNER/$REPO/actions/runs/$WORKFLOW_ID"
           echo "ARTIFACT_URL=$ARTIFACT_URL" >> $GITHUB_ENV
       - name: Delete old bot comments
-        if: ${{ github.event_name == 'pull_request' }}
         env:
           GH_TOKEN: ${{ github.token }}
           PR_ID: ${{ github.event.pull_request.number }}
@@ -75,7 +79,6 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/{owner}/{repo}/issues/comments/%q
       - name: Post test package PR comment
-        if: ${{ github.event_name == 'pull_request' }}
         env:
           GH_TOKEN: ${{ github.token }}
           PR_ID: ${{ github.event.pull_request.number }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,9 @@ jobs:
             /repos/{owner}/{repo}/issues/comments/%q
       - name: Post test package PR comment
         if: ${{ github.event_name == 'pull_request' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_ID: ${{ github.event.pull_request.number }}
         run: |
           gh api \
             --method POST \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - uses: actions/checkout@v4
       - name: Get Artifact URL
         env:
           OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,9 @@ jobs:
   comment-on-pr:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Get Artifact URL
         env:
@@ -58,31 +61,70 @@ jobs:
       - name: Delete old bot comments
         if: ${{ github.event_name == 'pull_request' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PR_ID: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
         run: |
-          curl \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            https://api.github.com/repos/$REPO/issues/$PR_ID/comments \
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/{owner}/{repo}/issues/$PR_ID/comments \
           | jq ".[] | select(.user.login==\"github-actions[bot]\") | .id" \
-          | xargs -I %q curl \
-            -L \
-            -X DELETE \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token $GITHUB_TOKEN"\
-            https://api.github.com/repos/$REPO/issues/comments/%q
+          | xargs -I %q gh api \
+            --method DELETE \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/{owner}/{repo}/issues/comments/%q
       - name: Post test package PR comment
         if: ${{ github.event_name == 'pull_request' }}
-        env:
-          VERSION: ${{ steps.published-version.outputs.version }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_URL: ${{ github.event.pull_request.comments_url }}
         run: |
-          curl \
-            -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            $GITHUB_URL \
-            -d "{\"body\":\"> Test with build here: ${{ env.ARTIFACT_URL }}\"}"
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/{owner}/{repo}/issues/$PR_ID/comments \
+            -f body="Test with build here: $ARTIFACT_URL"
+  publish-github-release-candidate:
+    if: ${{ github.base_ref == 'main' && startsWith(github.head_ref, 'release/')}}
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - id: publish-prerelease-rc
+        name: Publish prerelease rc
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_ID: ${{ github.event.pull_request.number }}
+          SOURCE_BRANCH: ${{ github.head_ref }}
+        run: |
+          # find the next rc tag
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/{owner}/{repo}/releases > releases.json
+          TAG=$(echo $SOURCE_BRANCH | sed 's/release\/\(.*\)/\1/')
+          ./find-tag.sh # look up releases.json and export $NEXT_TAG
+          # publish the github release
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/{owner}/{repo}/releases \
+            -f tag_name="$NEXT_TAG" \
+            -f target_commitish="$SOURCE_BRANCH" \
+            -f name="$NEXT_TAG" \
+            -F draft=false \
+            -F prerelease=true \
+            -F generate_release_notes=true > release.json
+          # update PR description
+          cat release.json | jq -r .body > body.md
+          echo -e "\n\nRelease candidate: $(cat release.json | jq -r .html_url)" >> body.md
+          echo -e "\nTo publish a latest release: Merge Commit this PR" >> body.md
+          gh api \
+            --method PATCH \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/{owner}/{repo}/pulls/$PR_ID \
+            -F 'body=@body.md'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build for PR
+name: Build & Test for PR
 ##
 # This workflow tests, builds, and uploads the extension code for each PR
 #

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build & Test for PR
+name: Build & Test for feature PR
 ##
 # This workflow tests, builds, and uploads the extension code for each PR
 #

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,5 +1,9 @@
 name: Create release PRs
-
+##
+# This workflow initiates the release process (create release PRs):
+# - creates a release branch with version bump
+# - creates a release PR to main & develop
+#
 on:
   workflow_dispatch:
     inputs:
@@ -12,13 +16,6 @@ on:
           - patch
           - minor
           - major
-
-##
-# This workflow initiates the release process (create release PRs):
-# - creates a release branch with version bump
-# - creates a release PR to main
-# - creates a release PR to develop
-#
 jobs:
   create-release-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,4 +1,4 @@
-name: Create release PR
+name: Create release PRs
 
 on:
   workflow_dispatch:
@@ -13,6 +13,12 @@ on:
           - minor
           - major
 
+##
+# This workflow initiates the release process (create release PRs):
+# - creates a release branch with version bump
+# - creates a release PR to main
+# - creates a release PR to develop
+#
 jobs:
   create-release-pr:
     runs-on: ubuntu-latest
@@ -21,8 +27,8 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,50 +1,61 @@
-name: Release
+name: Publish Latest Release
 
 on:
-  release:
-    types: [created]
+  pull_request:
+    branches:
+      - main
+    types: [ closed ]
 
+##
+# This workflow creates a latest release with the same target_commitish
+# as the highest rc matching the release PR version
+#
+# It should also update the release PR description
+# It should also attach the highest rc asset to the latest release
+#
 jobs:
-  build:
+  publish-latest:
+    if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')}}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          always-auth: true
-          node-version: '18.x'
-          registry-url: https://npm.pkg.github.com
-          scope: '@secretkeylabs'
-      - name: Install dependencies
+      - id: set-latest
+        name: Set latest
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGE_REGISTRY_TOKEN }}
-        run: npm ci
-      - name: Test
+          GH_TOKEN: ${{ github.token }}
+          PR_ID: ${{ github.event.pull_request.number }}
+          SOURCE_BRANCH: ${{ github.head_ref }}
         run: |
-          npx eslint .
-          npx tsc --noEmit
-          npm test
-      - name: Build
-        env:
-          TRANSAC_API_KEY: ${{ secrets.TRANSAC_API_KEY }}
-          MOON_PAY_API_KEY: ${{ secrets.MOON_PAY_API_KEY }}
-          MIX_PANEL_TOKEN: ${{ secrets.MIX_PANEL_TOKEN }}
-        run: npm run build --if-present
-      - name: Save Filename
-        id: save-filename
-        run: |
-          echo "FILENAME=xverse-extension.$(echo ${{github.ref_name}}| sed 's/\//-/').zip" >> $GITHUB_OUTPUT
-      - name: Create Archive
-        run: |
-          zip -rj build.zip ./build
-      - name: Upload Release Asset
-        if: ${{ github.event.release.upload_url }}
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: build.zip
-          asset_name: ${{ steps.save-filename.outputs.FILENAME }}
-          asset_content_type: application/zip
+          # find the target commitish of the latest release matching our tag
+          TAG=$(echo $SOURCE_BRANCH | sed 's/release\/\(.*\)/\1/')
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/{owner}/{repo}/releases > releases.json
+          TARGET_COMMITISH=$(cat releases.json | jq '.[] | select(.tag_name | match("$TAG")) | .target_commitish' | head -1)
+          # publish the latest release
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/{owner}/{repo}/releases \
+            -f tag_name="$TAG" \
+            -f target_commitish="$TARGET_COMMITISH" \
+            -f name="$TAG" \
+            -F generate_release_notes=true > release.json
+          # update PR description
+          cat release.json | jq -r .body > body.md
+          echo -e "\n\nPublished latest release: $(cat release.json | jq -r .html_url)" >> body.md
+          gh api \
+            --method PATCH \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/{owner}/{repo}/pulls/$PR_ID \
+            -F 'body=@body.md'
+          # TODO attach the rc asset to latest release
+          # save output for upload
+          # echo "FILENAME=xverse-web-extension.$TAG.zip" >> $GITHUB_OUTPUT
+          # echo "UPLOAD_URL=$(cat release.json | jq -r .upload_url)" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish Latest Release
+name: Publish latest release
 ##
 # This workflow creates a latest release with the same target_commitish
 # as the highest rc matching the release PR version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,9 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - id: set-latest
-        name: Set latest
+      - uses: actions/checkout@v4
+      - id: create-latest-release
+        name: Create latest release
         env:
           GH_TOKEN: ${{ github.token }}
           PR_ID: ${{ github.event.pull_request.number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,4 @@
 name: Publish Latest Release
-
-on:
-  pull_request:
-    branches:
-      - main
-    types: [ closed ]
-
 ##
 # This workflow creates a latest release with the same target_commitish
 # as the highest rc matching the release PR version
@@ -13,6 +6,12 @@ on:
 # It should also update the release PR description
 # It should also attach the highest rc asset to the latest release
 #
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
 jobs:
   publish-latest:
     if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')}}
@@ -21,13 +20,13 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
       - id: create-latest-release
         name: Create latest release
         env:
-          GH_TOKEN: ${{ github.token }}
-          PR_ID: ${{ github.event.pull_request.number }}
           SOURCE_BRANCH: ${{ github.head_ref }}
         run: |
           # find the target commitish of the latest release matching our tag
@@ -47,6 +46,15 @@ jobs:
             -f target_commitish="$TARGET_COMMITISH" \
             -f name="$TAG" \
             -F generate_release_notes=true > release.json
+          # TODO attach the rc asset to latest release
+          # save output for upload
+          # echo "FILENAME=xverse-web-extension.$TAG.zip" >> $GITHUB_OUTPUT
+          # echo "UPLOAD_URL=$(cat release.json | jq -r .upload_url)" >> $GITHUB_OUTPUT
+      - id: update-description
+        name: Update PR description with release notes
+        env:
+          PR_ID: ${{ github.event.pull_request.number }}
+        run: |
           # update PR description
           cat release.json | jq -r .body > body.md
           echo -e "\n\nPublished latest release: $(cat release.json | jq -r .html_url)" >> body.md
@@ -56,7 +64,3 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/{owner}/{repo}/pulls/$PR_ID \
             -F 'body=@body.md'
-          # TODO attach the rc asset to latest release
-          # save output for upload
-          # echo "FILENAME=xverse-web-extension.$TAG.zip" >> $GITHUB_OUTPUT
-          # echo "UPLOAD_URL=$(cat release.json | jq -r .upload_url)" >> $GITHUB_OUTPUT

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,3 +1,4 @@
 release.json
 pr-*.json
 body.md
+releases.json

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -1,4 +1,11 @@
 #! /bin/bash
+#
+##
+# create-release-pr.sh for xverse-web-extension
+#
+# NOTE: make sure you git commit your work before running this.
+# Alternatively trigger it from the github action
+#
 
 if [[ -z "$BUMP" ]]; then
   echo "BUMP is required. major|minor|patch"

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -1,9 +1,9 @@
 #! /bin/bash
-#
+
 ##
 # create-release-pr.sh for xverse-web-extension
 #
-# NOTE: make sure you git commit your work before running this.
+# NOTE: make sure you git commit your work before running this locally.
 # Alternatively trigger it from the github action
 #
 
@@ -30,23 +30,6 @@ git merge origin/main -s ours
 
 git push --set-upstream origin $BRANCH
 
-echo -e "\n--- Create draft release for $TAG ---"
-
-gh api \
-  --method POST \
-  -H "Accept: application/vnd.github+json" \
-  -H "X-GitHub-Api-Version: 2022-11-28" \
-  /repos/{owner}/{repo}/releases \
-  -f tag_name=$TAG \
-  -f target_commitish="$BRANCH" \
-  -f name=$TAG \
-  -F draft=true \
-  -F prerelease=true \
-  -F generate_release_notes=true > release.json
-
-cat release.json | jq -r .body > body.md
-echo -e "\n\nDraft release: $(cat release.json | jq -r .html_url)" >> body.md
-
 for b in main develop; do
   echo -e "\n--- Create PR to $b ---"
 
@@ -59,17 +42,6 @@ for b in main develop; do
     -f body="Created by GitHub Actions Bot" \
     -f head="$BRANCH" \
     -f base="$b" > pr-$b.json
-
-  echo -e "\n--- Update PR to $b with description ---"
-
-  PR_ID=$(cat pr-$b.json | jq -r .number)
-
-  gh api \
-    --method PATCH \
-    -H "Accept: application/vnd.github+json" \
-    -H "X-GitHub-Api-Version: 2022-11-28" \
-    /repos/{owner}/{repo}/pulls/$PR_ID \
-    -F 'body=@body.md'
 
   # clean up temp files
   # rm pr-$b.json

--- a/scripts/find-tag.sh
+++ b/scripts/find-tag.sh
@@ -1,0 +1,29 @@
+#! /bin/bash
+
+##
+# find-tag.sh
+#
+# a util for looking through a list of github releases and exporting the next tag
+#
+if [[ -z "$TAG" ]]; then
+  echo "TAG is required. e.g. v0.26.0"
+  exit 1
+fi
+
+if cat releases.json | jq '.[].tag_name' | grep $TAG; then
+  echo found releases matching $TAG
+  LATEST_TAG=$(cat releases.json | jq '.[].tag_name' | grep $TAG | head -1)
+  LATEST_RC=$(echo $LATEST_TAG | grep rc | sed 's/.*-rc\(.*\)/\1/')
+  if [[ -z "$LATEST_RC" ]]; then
+    echo $TAG was already released
+    exit 1;
+  elif [[ -n "$LATEST_RC" ]]; then
+    NEXT_TAG="$TAG-rc.$($LATEST_RC +1)"
+  fi
+else
+  echo no releases matching $TAG yet
+  NEXT_TAG="$TAG-rc.0"
+fi
+
+echo next tag will be $NEXT_TAG
+export NEXT_TAG=$NEXT_TAG


### PR DESCRIPTION
# 🔘 PR Type
- [x] CI related changes

# 📜 Background
https://www.notion.so/xverseapp/Xverse-Web-Extension-Release-Instructions-f850e51a4a9f4eba94b9ad27eb8beca6

automating steps 6-8

https://linear.app/xverseapp/issue/ENG-3325

# 🔄 Changes
- required some refactoring of the workflows
  - refactor build.yaml to:
    - trigger only for PRs not named like a release PR
  - create a build-rc.yaml for release PRs to:
    - trigger on pull_request events to main & develop named like a release PR
    - create the release (moved from create-release-pr.yml) 
    - build and upload the release asset (moved from release.yml) 
  - refactor release.yaml to:
    - trigger on merge of release PR to main
    - look for the latest release candidate and create the 'latest' release with the same target_comittish