### PR TITLE
[ENG-3455] fix: Fix the sharp fee change on tx confirmation

### DIFF
--- a/src/app/screens/confirmFtTransaction/index.tsx
+++ b/src/app/screens/confirmFtTransaction/index.tsx
@@ -13,7 +13,7 @@ import { deserializeTransaction } from '@stacks/transactions';
 import { useMutation } from '@tanstack/react-query';
 import { isLedgerAccount } from '@utils/helper';
 import BigNumber from 'bignumber.js';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -22,8 +22,14 @@ function ConfirmFtTransaction() {
   const navigate = useNavigate();
   const selectedNetwork = useNetworkSelector();
   const location = useLocation();
-  const { unsignedTx: seedHex, amount, fungibleToken, memo, recepientAddress } = location.state;
-  const unsignedTx = deserializeTransaction(seedHex);
+  const {
+    unsignedTx: unsignedTxHex,
+    amount,
+    fungibleToken,
+    memo,
+    recepientAddress,
+  } = location.state;
+  const unsignedTx = useMemo(() => deserializeTransaction(unsignedTxHex), [unsignedTxHex]);
   const { refetch } = useStxWalletData();
   const { network, selectedAccount } = useWalletSelector();
 

--- a/src/app/screens/confirmNftTransaction/index.tsx
+++ b/src/app/screens/confirmNftTransaction/index.tsx
@@ -17,7 +17,7 @@ import { deserializeTransaction } from '@stacks/transactions';
 import { useMutation } from '@tanstack/react-query';
 import { isLedgerAccount } from '@utils/helper';
 import BigNumber from 'bignumber.js';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
@@ -74,7 +74,7 @@ function ConfirmNftTransaction() {
   const nft = nftDetailQuery.data?.data;
 
   const { unsignedTx: unsignedTxHex, recipientAddress } = location.state;
-  const unsignedTx = deserializeTransaction(unsignedTxHex);
+  const unsignedTx = useMemo(() => deserializeTransaction(unsignedTxHex), [unsignedTxHex]);
   const { network } = useWalletSelector();
   const { refetch } = useStxWalletData();
   const selectedNetwork = useNetworkSelector();

--- a/src/app/screens/confirmStxTransaction/index.tsx
+++ b/src/app/screens/confirmStxTransaction/index.tsx
@@ -24,7 +24,7 @@ import { deserializeTransaction } from '@stacks/transactions';
 import { useMutation } from '@tanstack/react-query';
 import { isLedgerAccount } from '@utils/helper';
 import BigNumber from 'bignumber.js';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
@@ -49,7 +49,7 @@ function ConfirmStxTransaction() {
   const location = useLocation();
   const selectedNetwork = useNetworkSelector();
   const { unsignedTx: stringHex, sponsored, isBrowserTx, tabId, requestToken } = location.state;
-  const unsignedTx = deserializeTransaction(stringHex);
+  const unsignedTx = useMemo(() => deserializeTransaction(stringHex), [stringHex]);
   useOnOriginTabClose(Number(tabId), () => {
     setHasTabClosed(true);
     window.scrollTo({ top: 0, behavior: 'smooth' });


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background
UI issue with the fee state when you press confirm. It suddenly flashes to a different number before it gets broadcasted. It doesn’t actually get sent as the wrong number but really concerning for users when it does that.

Issue Link: #[[ENG-3455](https://linear.app/xverseapp/issue/ENG-3455/fix-the-sharp-fee-change-on-tx-confirmation)]
Context Link (if applicable):

# 🔄 Changes
Enumerate the changes made in this pull request, detailing what has been modified, added, or removed. Include technical details and implications if necessary.

Impact:
- Explain the broader impact of these changes.
- How it improves performance, fixes bugs, adds functionality, etc.

# 🖼 Screenshot / 📹 Video
Before:

https://github.com/secretkeylabs/xverse-web-extension/assets/36603049/5f7add93-d719-4032-9ae5-d32640418285

After:

https://github.com/secretkeylabs/xverse-web-extension/assets/36603049/864e10a6-f888-4fb0-a0d9-59cb87f4b495


# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
