### PR TITLE
Tim/eng 3475 nonce not updating correctly after switching accounts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ledgerhq/hw-transport-webusb": "^6.27.13",
         "@phosphor-icons/react": "^2.0.10",
         "@react-spring/web": "^9.6.1",
-        "@secretkeylabs/xverse-core": "6.0.1-3d747a3",
+        "@secretkeylabs/xverse-core": "7.0.0",
         "@stacks/connect": "7.4.1",
         "@stacks/stacks-blockchain-api-types": "6.1.1",
         "@stacks/transactions": "6.9.0",
@@ -1732,9 +1732,9 @@
       }
     },
     "node_modules/@secretkeylabs/xverse-core": {
-      "version": "6.0.1-3d747a3",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/6.0.1-3d747a3/219b63e085fd01f85abaa42902b9759e050e0236",
-      "integrity": "sha512-oRwgA69GYsmknpSZ6evDtbAR3wOdxcMKPbi+sea8/8KHXLTbA6m1qhmBKypGsIALSS38dFQ9JZuEKfVpwQ6iig==",
+      "version": "7.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/7.0.0/a9d4470c0bee31b2b751b0f2a3e064d51453ddd4",
+      "integrity": "sha512-8z5g5dHFin0d9695EwI0t6a/Ji7vzUenCq1AHpTtsj5Z1/SlH6Oa7p95fyJ1usBH99M5NQAYFMBGkjOcNE+jQw==",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
@@ -15372,9 +15372,9 @@
       }
     },
     "@secretkeylabs/xverse-core": {
-      "version": "6.0.1-3d747a3",
-      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/6.0.1-3d747a3/219b63e085fd01f85abaa42902b9759e050e0236",
-      "integrity": "sha512-oRwgA69GYsmknpSZ6evDtbAR3wOdxcMKPbi+sea8/8KHXLTbA6m1qhmBKypGsIALSS38dFQ9JZuEKfVpwQ6iig==",
+      "version": "7.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@secretkeylabs/xverse-core/7.0.0/a9d4470c0bee31b2b751b0f2a3e064d51453ddd4",
+      "integrity": "sha512-8z5g5dHFin0d9695EwI0t6a/Ji7vzUenCq1AHpTtsj5Z1/SlH6Oa7p95fyJ1usBH99M5NQAYFMBGkjOcNE+jQw==",
       "requires": {
         "@bitcoinerlab/secp256k1": "^1.0.2",
         "@noble/curves": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@ledgerhq/hw-transport-webusb": "^6.27.13",
     "@phosphor-icons/react": "^2.0.10",
     "@react-spring/web": "^9.6.1",
-    "@secretkeylabs/xverse-core": "6.0.1-3d747a3",
+    "@secretkeylabs/xverse-core": "7.0.0",
     "@stacks/connect": "7.4.1",
     "@stacks/stacks-blockchain-api-types": "6.1.1",
     "@stacks/transactions": "6.9.0",

--- a/src/app/components/transactionSetting/editNonce.tsx
+++ b/src/app/components/transactionSetting/editNonce.tsx
@@ -58,7 +58,7 @@ function EditNonce({ nonce, setNonce }: Props) {
 
   useEffect(() => {
     setNonce(nonceInput);
-  }, [nonceInput]);
+  }, [nonceInput, setNonce]);
 
   return (
     <NonceContainer>

--- a/src/app/hooks/queries/useStxWalletData.ts
+++ b/src/app/hooks/queries/useStxWalletData.ts
@@ -7,6 +7,7 @@ import { useDispatch } from 'react-redux';
 import useNetworkSelector from '../useNetwork';
 import useWalletSelector from '../useWalletSelector';
 
+// TODO refactor: no need to put this in store. use this hook instead
 export const useStxWalletData = () => {
   const dispatch = useDispatch();
   const { stxAddress } = useWalletSelector();

--- a/src/app/screens/transactionRequest/index.tsx
+++ b/src/app/screens/transactionRequest/index.tsx
@@ -33,8 +33,7 @@ const LoaderContainer = styled.div((props) => ({
 }));
 
 function TransactionRequest() {
-  const { stxAddress, network, stxPublicKey, feeMultipliers, accountsList, selectedAccount } =
-    useWalletSelector();
+  const { network, feeMultipliers, accountsList, selectedAccount } = useWalletSelector();
   const { payload, tabId, requestToken, stacksTransaction } = useStxTransactionRequest();
   const navigate = useNavigate();
   const selectedNetwork = useNetworkSelector();
@@ -47,7 +46,10 @@ function TransactionRequest() {
   const [attachment, setAttachment] = useState<Buffer | undefined>(undefined);
 
   const handleTokenTransferRequest = async (tokenTransferPayload: any, requestAccount: Account) => {
-    const stxPendingTxData = await fetchStxPendingTxData(stxAddress, selectedNetwork);
+    const stxPendingTxData = await fetchStxPendingTxData(
+      requestAccount.stxAddress,
+      selectedNetwork,
+    );
     const unsignedSendStxTx = await getTokenTransferRequest(
       tokenTransferPayload.recipient,
       tokenTransferPayload.amount,

--- a/src/app/screens/transactionRequest/index.tsx
+++ b/src/app/screens/transactionRequest/index.tsx
@@ -55,7 +55,11 @@ function TransactionRequest() {
       tokenTransferPayload.amount,
       tokenTransferPayload.memo!,
       requestAccount.stxPublicKey,
-      feeMultipliers!,
+      {
+        stxSendTxMultiplier: feeMultipliers?.stxSendTxMultiplier || 1,
+        poolStackingTxMultiplier: feeMultipliers?.poolStackingTxMultiplier || 1,
+        otherTxMultiplier: feeMultipliers?.otherTxMultiplier || 1,
+      },
       selectedNetwork,
       stxPendingTxData || [],
       stacksTransaction?.auth,
@@ -193,7 +197,7 @@ function TransactionRequest() {
           },
         });
       }
-    } else {
+    } else if (selectedAccount) {
       await createRequestTx(selectedAccount!);
     }
   };

--- a/src/app/screens/transactionRequest/index.tsx
+++ b/src/app/screens/transactionRequest/index.tsx
@@ -18,6 +18,7 @@ import { ContractCallPayload, ContractDeployPayload } from '@stacks/connect';
 import { StacksTransaction } from '@stacks/transactions';
 import { getNetworkType, isHardwareAccount } from '@utils/helper';
 import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 import { MoonLoader } from 'react-spinners';
 import styled from 'styled-components';
@@ -134,8 +135,8 @@ function TransactionRequest() {
       });
     }
   };
-
   const createRequestTx = async () => {
+    try {
       if (!payload.txHex) {
         if (payload.txType === 'token_transfer') {
           await handleTokenTransferRequest(payload);
@@ -143,12 +144,15 @@ function TransactionRequest() {
           await handleContractCallRequest(payload);
         } else if (payload.txType === 'smart_contract') {
           await handleContractDeployRequest(payload);
+        } else {
+          await handleTxSigningRequest();
         }
-      } else {
-        await handleTxSigningRequest();
       }
-  }
-
+    } catch (e: unknown) {
+      console.error(e); // eslint-disable-line
+      toast.error('Unexpected error creating transaction');
+    }
+  };
 
   createRequestTx();
 

--- a/src/app/stores/wallet/reducer.ts
+++ b/src/app/stores/wallet/reducer.ts
@@ -31,6 +31,37 @@ import {
   WalletState,
 } from './actions/types';
 
+/*
+ * This store should ONLY be used for global app settings such as:
+ *  - hasActivatedOrdinalsKey: undefined,
+ *  - hasActivatedRareSatsKey: undefined,
+ *  - hasActivatedRBFKey: true,
+ *  - rareSatsNoticeDismissed: undefined,
+ *  - showBtcReceiveAlert: true,
+ *  - showOrdinalReceiveAlert: true,
+ *  - showDataCollectionAlert: true,
+ *  - btcApiUrl: '',
+ *  - selectedAccount: null,
+ *  - accountType: 'software',
+ *  - accountName: undefined,
+ *  - walletLockPeriod: WalletSessionPeriods.STANDARD,
+ *  - isUnlocked: false,
+ *  - fiatCurrency: 'USD',
+ *
+ * because we get many bugs around caching the wrong values when switching accounts,
+ * we prefer react-query cache (with the correct cache keys) for all
+ * account-specific values, and API fetch results such as:
+ *  - btcFiatRate: '0',
+ *  - stxBtcRate: '0',
+ *  - stxBalance: '0',
+ *  - stxAvailableBalance: '0',
+ *  - stxLockedBalance: '0',
+ *  - stxNonce: 0,
+ *  - btcBalance: '0',
+ *  - feeMultipliers: null,
+ *
+ * TODO refactor most of these values out of the store and use query cache instead
+ */
 const initialWalletState: WalletState = {
   stxAddress: '',
   btcAddress: '',


### PR DESCRIPTION
# 🔘 PR Type
- [x] Bugfix

# 📜 Background
Issue Link: https://linear.app/xverseapp/issue/ENG-3475

there is a feature on the transaction request screen which checks a dapp tx request popup payload and does an auto account switch if there is a mismatch.

scenario 1:
if I signed in with account 1 on the dapp, and switched my extension to account 2,
expect the popup for a dapp tx will auto switch my account back to the one matching what I signed into the dapp with.

# 🔄 Changes
this fix doesn't change the behaviour, but ensures the auto switch also regenerates the unsignedTx with the correct account (and therefore displays the correct nonce in Edit Nonce)

- fix: bug where transaction request screen would initiate an auto account switch, but not regenerate the unsignedTx

Impact:
- STX transaction request screen
- only used when interacting with dapps

# 🖼 Screenshot / 📹 Video
after fix:

https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/3bbd8788-4559-4f14-9736-55e88df8702e


also tested with pending transactions, and nonce increments as expected

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
