### PR TITLE
feat: unconfirmed utxo warning in sign psbt

### DIFF
--- a/src/app/components/confirmBtcTransaction/transactionSummary.tsx
+++ b/src/app/components/confirmBtcTransaction/transactionSummary.tsx
@@ -23,6 +23,10 @@ const InscribedRareSatWarning = styled(Callout)`
   margin-bottom: ${(props) => props.theme.space.m};
 `;
 
+const UnconfirmedInputCallout = styled(Callout)`
+  margin-bottom: ${(props) => props.theme.space.m};
+`;
+
 type Props = {
   isPartialTransaction: boolean;
 
@@ -77,6 +81,8 @@ function TransactionSummary({
     ordinalsAddress,
   });
 
+  const isUnConfirmedInput = inputs.some((input) => !input.extendedUtxo.utxo.status.confirmed);
+
   const paymentHasInscribedRareSats = isPartialTransaction
     ? inputs.some(
         (input) =>
@@ -112,6 +118,10 @@ function TransactionSummary({
           redirectText={settingsT('RECOVER_ASSETS')}
           onClickRedirect={goToRecoverAssets}
         />
+      )}
+
+      {isUnConfirmedInput && (
+        <UnconfirmedInputCallout bodyText={t('UNCONFIRMED_UTXO_WARNING')} variant="warning" />
       )}
 
       <TransferSection

--- a/src/app/screens/signPsbtRequest/tempMockDataUtil.ts
+++ b/src/app/screens/signPsbtRequest/tempMockDataUtil.ts
@@ -24,6 +24,9 @@ const getPsbtDataWithMocks = (
           // @ts-ignore
           utxo: {
             value: 100000,
+            status: {
+              confirmed: false, // to test the unconfirmed utxo warning callout
+            },
           },
         },
         inscriptions: [

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -382,7 +382,8 @@
     "YOUR_PAYMENT_ADDRESS": "Your payment address",
     "INSCRIBED_SATS": "Some of these sats are inscribed",
     "INSCRIBED_RARE_SATS": "Some of these sats are rare or inscribed",
-    "INSCRIBED_RARE_SATS_WARNING": "Your payment wallet holds assets. To avoid spending them in your transactions and fees, transfer them to your ordinals wallet."
+    "INSCRIBED_RARE_SATS_WARNING": "Your payment wallet holds assets. To avoid spending them in your transactions and fees, transfer them to your ordinals wallet.",
+    "UNCONFIRMED_UTXO_WARNING": "You are spending unconfirmed outputs in this transaction. This may lower the effective fee rate causing delays in transaction confirmation"
   },
   "TX_ERRORS": {
     "INSUFFICIENT_BALANCE": "The requested transaction cannot be created due to insufficient balance",


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background
We need to add a warning in sign psbt screen if we are spending unconfirmed utxos in inputs

Issue Link: https://github.com/secretkeylabs/xverse-web-extension/pull/728
Context Link (if applicable):

# 🔄 Changes
- show callout if any of the inputs of the transaction has an unconfirmed status

Impact:
- Sign Psbt screen

# 🖼 Screenshot / 📹 Video

<img width="360" alt="Screenshot 2023-12-27 at 3 27 43 PM" src="https://github.com/secretkeylabs/xverse-web-extension/assets/29428363/a5bc8dc5-edc2-44a6-9177-e1737c301a2b">

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
