### PR TITLE
chore: add showContentTypeThumbnail prop to ordinal image component and use it in psbt screens

### DIFF
--- a/src/app/components/confirmBtcTransaction/itemRow/inscription.tsx
+++ b/src/app/components/confirmBtcTransaction/itemRow/inscription.tsx
@@ -64,6 +64,7 @@ export default function Inscription({
                 content_type: inscription.contentType,
               }}
               placeholderIcon={OrdinalIcon}
+              showContentTypeThumbnail
             />
           }
         />

--- a/src/app/screens/ordinals/ordinalImage.tsx
+++ b/src/app/screens/ordinals/ordinalImage.tsx
@@ -3,6 +3,7 @@ import OrdinalsIcon from '@assets/img/nftDashboard/white_ordinals_icon.svg';
 import { BetterBarLoader } from '@components/barLoader';
 import useTextOrdinalContent from '@hooks/useTextOrdinalContent';
 import useWalletSelector from '@hooks/useWalletSelector';
+import { TextT } from '@phosphor-icons/react';
 import { CondensedInscription, getErc721Metadata, Inscription } from '@secretkeylabs/xverse-core';
 import { getBrc20Details } from '@utils/brc20';
 import { XVERSE_ORDIVIEW_URL } from '@utils/constants';
@@ -11,6 +12,7 @@ import Image from 'rc-image';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
+import Theme from 'theme';
 import Brc20Tile from './brc20Tile';
 
 interface ContainerProps {
@@ -118,6 +120,14 @@ const StyledImage = styled(Image)`
   image-rendering: pixelated;
   display: flex;
 `;
+const ContentTypeThumbnailContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  background-color: ${(props) => props.theme.colors.white_0};
+`;
 
 export const StyledBarLoader = styled(BetterBarLoader)((props) => ({
   padding: 0,
@@ -134,6 +144,7 @@ interface Props {
   withoutSizeIncrease?: boolean;
   withoutTitles?: boolean;
   placeholderIcon?: string;
+  showContentTypeThumbnail?: boolean;
 }
 
 function OrdinalImage({
@@ -145,6 +156,7 @@ function OrdinalImage({
   withoutSizeIncrease = false,
   withoutTitles = false,
   placeholderIcon,
+  showContentTypeThumbnail = false,
 }: Props) {
   const isGalleryOpen: boolean = document.documentElement.clientWidth > 360 && !withoutSizeIncrease;
   const textContent = useTextOrdinalContent(ordinal);
@@ -267,6 +279,16 @@ function OrdinalImage({
               <Text>{t('ORDINAL')}</Text>
             </OrdinalsTag>
           )}
+        </ImageContainer>
+      );
+    }
+
+    if (showContentTypeThumbnail) {
+      return (
+        <ImageContainer>
+          <ContentTypeThumbnailContainer>
+            <TextT width="50%" height="50%" color={Theme.colors.elevation0} weight="bold" />
+          </ContentTypeThumbnailContainer>
         </ImageContainer>
       );
     }

--- a/src/app/screens/ordinals/ordinalImage.tsx
+++ b/src/app/screens/ordinals/ordinalImage.tsx
@@ -287,7 +287,7 @@ function OrdinalImage({
       return (
         <ImageContainer>
           <ContentTypeThumbnailContainer>
-            <TextT width="50%" height="50%" color={Theme.colors.elevation0} weight="bold" />
+            <TextT width="50%" height="50%" color={Theme.colors.elevation0} />
           </ContentTypeThumbnailContainer>
         </ImageContainer>
       );


### PR DESCRIPTION
# 🔘 PR Type

- Enhancement

# 📜 Background

This PR adds the showContentTypeThumbnail prop to ordinal image component to use it psbt screens

Issue Link: #[ENG-3534](https://linear.app/xverseapp/issue/ENG-3534/make-sure-thumbnail-looks-good-for-sats-inscriptions-in-extension-and)


Impact:
- PSBT screens for content type of text/plain


# 🖼 Screenshot / 📹 Video
| BEFORE | AFTER |
| :---: | :---: |
| <img src='https://github.com/secretkeylabs/xverse-web-extension/assets/18606335/7770b00f-f56f-48bf-9dbc-1002c0edf032' width="50%" height="100%"> | <img src='https://github.com/secretkeylabs/xverse-web-extension/assets/18606335/e6415acf-f7b8-4c80-a577-7ae982a8930b' width="50%" height="100%"> |




# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
