### PR TITLE
[ENG-3567] fix: workaround for hiro api 429s on testnet while changing btc

### DIFF
--- a/src/app/screens/settings/changeNetwork/index.tsx
+++ b/src/app/screens/settings/changeNetwork/index.tsx
@@ -70,6 +70,9 @@ function ChangeNetworkScreen() {
   };
 
   const onNetworkSelected = (networkSelected: SettingsNetwork) => {
+    if (networkSelected.type === formInputs.type) {
+      return;
+    }
     setFormInputs(networkSelected);
     setFormErrors(initialNodeErrors);
   };
@@ -111,6 +114,8 @@ function ChangeNetworkScreen() {
   const onSubmit = async () => {
     setIsChangingNetwork(true);
 
+    // TODO use formik/yup for all validation if form gets more complex
+    // validate required fields
     if (!formInputs.address) {
       setFormErrors((prevErrors) => ({
         ...prevErrors,
@@ -129,10 +134,17 @@ function ChangeNetworkScreen() {
       return;
     }
 
+    const isChangedStacksUrl = formInputs.address !== network.address;
+    const isChangedBtcApiUrl = formInputs.btcApiUrl !== network.btcApiUrl;
+    const isChangedFallbackBtcApiUrl = formInputs.fallbackBtcApiUrl !== network.fallbackBtcApiUrl;
+
+    // validate against server if inputs were changed
     const [isValidStacksUrl, isValidBtcApiUrl, isValidFallbackBtcApiUrl] = await Promise.all([
-      isValidStacksApi(formInputs.address, formInputs.type),
-      isValidBtcApi(formInputs.btcApiUrl, formInputs.type),
-      !formInputs.fallbackBtcApiUrl || isValidBtcApi(formInputs.fallbackBtcApiUrl, formInputs.type),
+      !isChangedStacksUrl || isValidStacksApi(formInputs.address, formInputs.type),
+      !isChangedBtcApiUrl || isValidBtcApi(formInputs.btcApiUrl, formInputs.type),
+      !formInputs.fallbackBtcApiUrl ||
+        !isChangedFallbackBtcApiUrl ||
+        isValidBtcApi(formInputs.fallbackBtcApiUrl, formInputs.type),
     ]);
 
     if (isValidStacksUrl && isValidBtcApiUrl && isValidFallbackBtcApiUrl) {

--- a/src/app/screens/settings/changeNetwork/nodeInput.tsx
+++ b/src/app/screens/settings/changeNetwork/nodeInput.tsx
@@ -78,9 +78,11 @@ function NodeInput({
       </NodeInputHeader>
       <InputContainer>
         <Input onChange={onChange} value={value} />
-        <Button onClick={onClear}>
-          <XCircle size={18} weight="fill" color={theme.colors.white_200} />
-        </Button>
+        {value && (
+          <Button onClick={onClear}>
+            <XCircle size={18} weight="fill" color={theme.colors.white_200} />
+          </Button>
+        )}
       </InputContainer>
       <InputFeedback variant="danger" message={error} />
     </div>


### PR DESCRIPTION
# 🔘 PR Type
- [x] Bugfix

# 📜 Background
Provide a brief explanation of why this pull request is needed. Include the problem you are solving or the functionality you are adding. Reference any related issues.

Issue Link: #[issue_number]
Context Link (if applicable):

# 🔄 Changes
- fix: skip server validation of api urls if value didn't change
- and skip reset of form if selecting an already selected network
    (testnet/mainnet)
- and don't display the x button for clearing if input is empty

# 🖼 Screenshot / 📹 Video
https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/bc935e17-7383-4a15-98b9-897d9ea3c53b

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
