### PR TITLE
Fix indent on the Settings screen

### DIFF
--- a/src/app/screens/settings/settingComponent/index.tsx
+++ b/src/app/screens/settings/settingComponent/index.tsx
@@ -1,13 +1,6 @@
 import Switch from 'react-switch';
 import styled, { useTheme } from 'styled-components';
 
-interface ButtonProps {
-  border: string;
-}
-interface TitleProps {
-  textColor: string;
-}
-
 const CustomSwitch = styled(Switch)`
   .react-switch-handle {
     background-color: ${({ checked }) =>
@@ -16,56 +9,57 @@ const CustomSwitch = styled(Switch)`
   }
 `;
 
-const Button = styled.button<ButtonProps>((props) => ({
+const Button = styled.button<{
+  border: string;
+}>((props) => ({
   display: 'flex',
-  flexDirection: 'row',
   alignItems: 'center',
   background: 'transparent',
   justifyContent: 'flex-start',
-  marginTop: props.theme.spacing(6),
-  paddingBottom: props.theme.spacing(8),
+  paddingTop: props.theme.space.m,
+  paddingBottom: props.theme.space.m,
   borderBottom: props.border,
 }));
 
-const ColumnContainer = styled.div((props) => ({
+const ColumnContainer = styled.div({
   display: 'flex',
   flexDirection: 'column',
-}));
+});
 
 const TitleText = styled.h1((props) => ({
-  ...props.theme.body_bold_l,
+  ...props.theme.typography.body_bold_l,
   fontSize: 18,
-  paddingBottom: props.theme.spacing(6),
-  paddingTop: props.theme.spacing(16),
+  paddingBottom: props.theme.space.s,
+  paddingTop: props.theme.space.xl,
 }));
 
-const ComponentText = styled.h1<TitleProps>((props) => ({
-  ...props.theme.body_m,
-  paddingTop: props.theme.spacing(8),
+const ComponentText = styled.h1<{
+  textColor: string;
+}>((props) => ({
+  ...props.theme.typography.body_m,
   color: props.textColor,
   flex: 1,
   textAlign: 'left',
 }));
 
 const ComponentDescriptionText = styled.h1((props) => ({
-  ...props.theme.body_bold_m,
-  paddingTop: props.theme.spacing(8),
+  ...props.theme.typography.body_bold_m,
   color: props.theme.colors.white_0,
 }));
 
 const DescriptionText = styled.p((props) => ({
-  ...props.theme.body_m,
-  marginTop: props.theme.spacing(2),
+  ...props.theme.typography.body_m,
+  marginTop: props.theme.space.xxs,
   color: props.theme.colors.white_400,
   textAlign: 'left',
-  paddingRight: props.theme.spacing(8),
+  paddingRight: props.theme.space.m,
 }));
 
-const Column = styled.div((props) => ({
+const Column = styled.div({
   display: 'flex',
   flexDirection: 'column',
   flex: 1,
-}));
+});
 
 const DisabledOverlay = styled.div((props) => ({
   position: 'absolute',


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background
I noticed that we have too wide a vertical indent between the items and the arrow icon is not vertically centered for each of the items, this UI issue is only present on web-extension, and looks good on mobile. This PR aims to fix this UI issue.

![image](https://github.com/secretkeylabs/xverse-web-extension/assets/36603049/14da78be-e590-4fa1-962d-5ced8687348a)

Issue Link: #[[ENG-3572](https://linear.app/xverseapp/issue/ENG-3572/fix-indent-on-the-settings-screen)]
Context Link (if applicable):

# 🔄 Changes
Enumerate the changes made in this pull request, detailing what has been modified, added, or removed. Include technical details and implications if necessary.

Impact:
- Explain the broader impact of these changes.
- How it improves performance, fixes bugs, adds functionality, etc.

# 🖼 Screenshot / 📹 Video
![settings Monosnap Monosnap 2024-01-12 21-39-09](https://github.com/secretkeylabs/xverse-web-extension/assets/36603049/eca06281-0075-4610-b8f2-59658fba5bec)

![settings 2Monosnap Monosnap 2024-01-12 21-39-19](https://github.com/secretkeylabs/xverse-web-extension/assets/36603049/cc212752-061c-4b92-8ddd-3758c0a50fc7)

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
