### PR TITLE
fix: wrong variable used in validation to show top divider for first asset item in receive in payment section component

### DIFF
--- a/src/app/components/confirmBtcTransaction/receiveSection.tsx
+++ b/src/app/components/confirmBtcTransaction/receiveSection.tsx
@@ -57,7 +57,8 @@ function ReceiveSection({ outputs, netAmount, onShowInscription }: Props) {
     (output) => output.inscriptions.length > 0 || output.satributes.length > 0,
   );
   const areInscriptionsRareSatsInPayment = inscriptionsRareSatsInPayment.length > 0;
-  const showPaymentSection = areInscriptionsRareSatsInPayment || netAmount > 0;
+  const amountIsBiggerThanZero = netAmount > 0;
+  const showPaymentSection = areInscriptionsRareSatsInPayment || amountIsBiggerThanZero;
 
   return (
     <>
@@ -98,7 +99,7 @@ function ReceiveSection({ outputs, netAmount, onShowInscription }: Props) {
               <AddressLabel typography="body_medium_m">{t('YOUR_PAYMENT_ADDRESS')}</AddressLabel>
             </RowCenter>
           </Header>
-          {netAmount > 0 && (
+          {amountIsBiggerThanZero && (
             <RowContainer>
               <Amount amount={netAmount} />
             </RowContainer>
@@ -113,7 +114,7 @@ function ReceiveSection({ outputs, netAmount, onShowInscription }: Props) {
                 satributes={output.satributes}
                 amount={output.amount}
                 onShowInscription={onShowInscription}
-                showTopDivider={areInscriptionsRareSatsInPayment && index === 0}
+                showTopDivider={amountIsBiggerThanZero && index === 0}
                 showBottomDivider={inscriptionsRareSatsInPayment.length > index + 1}
               />
             ))}


### PR DESCRIPTION
# 🔘 PR Type

- Bugfix


# 📜 Background

This PR fixes a wrong variable used in validation to show top divider for first asset item in receive in payment section component

Issue Link: #[ENG-3584](https://linear.app/xverseapp/issue/ENG-3584/dont-show-divider-in-receive-in-payment-address-section-when-receiving)

Impact:
- PSBT and batch PSBT screens, receive section of the screen. This can be tested in a PSBT tx where user receives an asset in its payment address, maybe as a change 

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
