### PR TITLE
fix: Revert getBrc20Tokens to sequential call

### DIFF
--- a/src/app/hooks/queries/useBtcCoinsBalance.ts
+++ b/src/app/hooks/queries/useBtcCoinsBalance.ts
@@ -31,11 +31,12 @@ const useBtcCoinBalance = () => {
   // WITH additional supported tokens returned even if not passed
   const fetchBrcCoinsBalances = async () => {
     try {
-      // Fetch concurrently to speed things up
-      const [ordinalsFtBalance, brc20Tokens] = await Promise.all([
-        getOrdinalsFtBalance(network.type, ordinalsAddress),
-        getBrc20Tokens(network.type, brcCoinsList?.map((o) => o.ticker!) ?? [], fiatCurrency),
-      ]);
+      const ordinalsFtBalance = await getOrdinalsFtBalance(network.type, ordinalsAddress);
+      const brc20Tokens = await getBrc20Tokens(
+        network.type,
+        ordinalsFtBalance?.map((o) => o.ticker!) ?? [],
+        fiatCurrency,
+      );
 
       const brcCoinsListMap = new Map(brcCoinsList?.map((token) => [token.ticker, token]));
 


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

On a newly restored wallet, brcCoinsList will not be populated. As a such, the previous concurrent API calls will not be aware of owned ordinals which will cause no fiat value to be displayed for brc20 tokens. This PR will revert the concurrent calls to a sequential order, which has a slight speed impact, but will ensure that the fiat value will always be displayed.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background
Provide a brief explanation of why this pull request is needed. Include the problem you are solving or the functionality you are adding. Reference any related issues.

Issue Link: #[issue_number]
Context Link (if applicable):

# 🔄 Changes
Enumerate the changes made in this pull request, detailing what has been modified, added, or removed. Include technical details and implications if necessary.

Impact:
- Explain the broader impact of these changes.
- How it improves performance, fixes bugs, adds functionality, etc.

# 🖼 Screenshot / 📹 Video
Include screenshots or a video demonstrating the changes. This is especially helpful for UI changes.

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
