### PR TITLE
fix: hide stx in receive modal when stx token is disabled in token management screen

### DIFF
--- a/src/app/screens/home/index.tsx
+++ b/src/app/screens/home/index.tsx
@@ -378,7 +378,7 @@ function Home() {
         <MergedIcon src={ordinalsIcon} />
       </ReceiveCardComponent>
 
-      {stxAddress && !hideStx && (
+      {stxAddress && (
         <ReceiveCardComponent
           title={t('STACKS_AND_TOKEN')}
           address={stxAddress}


### PR DESCRIPTION
# 🔘 PR Type


- Bugfix

# 📜 Background

This PR fixes the issue around hiding stx in receive modal when stx token is disabled in token management screen

Issue Link: #[ENG-3658](https://linear.app/xverseapp/issue/ENG-3658/after-toggling-off-stx-address-should-be-available-in-the-receive)


# 🔄 Changes

- avoid hiding stx address in receive modal when stx token is disabled 

Impact:
- Receive modal, stx address row


# 🖼 Screenshot / 📹 Video

https://github.com/secretkeylabs/xverse-web-extension/assets/18606335/137f2405-f249-465b-aa24-3d386262b0e8



# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
