### PR TITLE
Ensure correct ordinal is shown in ordinal detail view

### DIFF
--- a/src/app/hooks/queries/ordinals/useInscription.ts
+++ b/src/app/hooks/queries/ordinals/useInscription.ts
@@ -6,10 +6,10 @@ import { handleRetries, InvalidParamsError } from '@utils/query';
 /**
  * Get inscriptions details by collection id
  */
-const useAddressInscription = (ordinalId: string, ordinal: Inscription | null) => {
+const useAddressInscription = (ordinalId: string, ordinal?: Inscription | null) => {
   const { ordinalsAddress, network } = useWalletSelector();
   const fetchOrdinals = async (): Promise<Inscription> => {
-    if (ordinal) return ordinal;
+    if (ordinal && ordinal.id === ordinalId) return ordinal;
     if (!ordinalsAddress || !ordinalId) {
       throw new InvalidParamsError('ordinalsAddress and ordinalId are required');
     }

--- a/src/app/screens/ordinalDetail/useOrdinalDetail.ts
+++ b/src/app/screens/ordinalDetail/useOrdinalDetail.ts
@@ -2,7 +2,6 @@ import { useGetUtxoOrdinalBundle } from '@hooks/queries/ordinals/useAddressRareS
 import useInscriptionCollectionMarketData from '@hooks/queries/ordinals/useCollectionMarketData';
 import useAddressInscription from '@hooks/queries/ordinals/useInscription';
 import usePendingOrdinalTxs from '@hooks/queries/usePendingOrdinalTx';
-import useNftDataSelector from '@hooks/stores/useNftDataSelector';
 import useOrdinalDataReducer from '@hooks/stores/useOrdinalReducer';
 import useSatBundleDataReducer from '@hooks/stores/useSatBundleReducer';
 import useTextOrdinalContent from '@hooks/useTextOrdinalContent';
@@ -23,8 +22,7 @@ export default function useOrdinalDetail() {
   const { ordinalsAddress, network, selectedAccount, hasActivatedRareSatsKey } =
     useWalletSelector();
   const { id } = useParams();
-  const { selectedOrdinal } = useNftDataSelector();
-  const { data: ordinalData, isLoading } = useAddressInscription(id!, selectedOrdinal);
+  const { data: ordinalData, isLoading } = useAddressInscription(id!);
   const { data: collectionMarketData } = useInscriptionCollectionMarketData(
     ordinalData?.collection_id,
   );


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background
This is a quick fix and first step to removing the selected NFT reducer. It ensures that the ordinal detail screen only shows the ordinal that the user selected.

# 🔄 Changes
Adds a check to ensure that the prepopulated ordinal data matches the selected ordinal.

To test:
1. Open the gallery page
2. Click on a collection
3. Click on an ordinal within the collection
4. Go back to the home screen from the bottom menu 
5. Go to the gallery view
6. Click on a different ordinal that is not part of a collection

The current prod version would show the first ordinal selected instead of the one you want to view. The new version will show the correct one.

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
