### PR TITLE
fix: fetch of brc20 in token management screen

### DIFF
--- a/src/app/hooks/queries/useAccountBalance.ts
+++ b/src/app/hooks/queries/useAccountBalance.ts
@@ -34,9 +34,11 @@ const useAccountBalance = () => {
   const fetchBrcCoinsBalances = async (ordinalsAddress: string) => {
     try {
       const ordinalsFtBalance = await getOrdinalsFtBalance(network.type, ordinalsAddress);
+      const tickers = ordinalsFtBalance?.map((o) => o.ticker!) ?? [];
       const brc20Tokens = await getBrc20Tokens(
         network.type,
-        ordinalsFtBalance?.map((o) => o.ticker!) ?? [],
+        // workaround for brc20 tokens not being returned
+        tickers.length ? tickers : ['ORDI'],
         fiatCurrency,
       );
 

--- a/src/app/hooks/queries/useBtcCoinsBalance.ts
+++ b/src/app/hooks/queries/useBtcCoinsBalance.ts
@@ -32,9 +32,11 @@ const useBtcCoinBalance = () => {
   const fetchBrcCoinsBalances = async () => {
     try {
       const ordinalsFtBalance = await getOrdinalsFtBalance(network.type, ordinalsAddress);
+      const tickers = ordinalsFtBalance?.map((o) => o.ticker!) ?? [];
       const brc20Tokens = await getBrc20Tokens(
         network.type,
-        ordinalsFtBalance?.map((o) => o.ticker!) ?? [],
+        // workaround for brc20 tokens not being returned
+        tickers.length ? tickers : ['ORDI'],
         fiatCurrency,
       );
 


### PR DESCRIPTION
# 🔘 PR Type


- Bugfix


# 📜 Background

Workaround to get BRC20 tokens in token management screen 



# 🔄 Changes

- if tickers is empty, use a hardcoded token to bypass issue in api handling of tickers param

Impact:
- BRC20 token management screen


# 🖼 Screenshot / 📹 Video
https://github.com/secretkeylabs/xverse-web-extension/assets/18606335/0e18e4b9-01d5-477f-9f01-de26f2b19781



# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
