### PR TITLE
fix: reset balance state between change accounts

### DIFF
--- a/src/app/stores/wallet/reducer.ts
+++ b/src/app/stores/wallet/reducer.ts
@@ -158,6 +158,15 @@ const walletReducer = (
         network: action.network,
         accountType: action.accountType,
         accountName: action.accountName,
+        btcBalance: '',
+        stxBalance: '',
+        stxAvailableBalance: '',
+        coinsList: state.coinsList
+          ? state.coinsList.map((coin) => ({ ...coin, balance: '0' }))
+          : [],
+        brcCoinsList: state.brcCoinsList
+          ? state.brcCoinsList.map((coin) => ({ ...coin, balance: '0' }))
+          : [],
       };
     case StoreEncryptedSeedKey:
       return {


### PR DESCRIPTION
# 🔘 PR Type
- [x] Bugfix

# 📜 Background
https://linear.app/xverseapp/issue/ENG-3674/balance-issue-in-ledger-account-on-v029-rc-sum-doesnt-match-assets

# 🔄 Changes
- reset all balances state in store, when switching accounts

Impact:
- Explain the broader impact of these changes.
- How it improves performance, fixes bugs, adds functionality, etc.

# 🖼 Screenshot / 📹 Video
before:
![image](https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/2ae7097f-b95e-4990-8b5a-c1b8585b14da)


after

https://github.com/secretkeylabs/xverse-web-extension/assets/6109710/d5f1bdfe-3117-4f84-8981-79abc2f58422





# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
