### PR TITLE
Remove fee subtraction from the You Will Transfer total - ENG-3699

### DIFF
--- a/src/app/components/confirmBtcTransaction/transactionSummary.tsx
+++ b/src/app/components/confirmBtcTransaction/transactionSummary.tsx
@@ -116,7 +116,7 @@ function TransactionSummary({
         inputs={inputs}
         isPartialTransaction={isPartialTransaction}
         onShowInscription={setInscriptionToShow}
-        netAmount={(netAmount + (feeOutput?.amount ?? 0)) * -1}
+        netAmount={-netAmount}
       />
 
       <ReceiveSection


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Enhancement

# 📜 Background
When showing a transaction summary, we calculate the total amount transferred as the total inputs from your address - the total outputs from your address - fee. This is potentially incorrect as we are assuming that the user is paying the fee, when they aren't necessarily.

# 🔄 Changes
No longer subtract the fee from the total being transferred.

Impact:
- This will affect the total transferred amount in the txn confirmation screen in the psbts' screen.

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
