### PR TITLE
feat: enable injection to all frames

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,7 +26,8 @@
     {
       "run_at": "document_start",
       "js": ["browser-polyfill.js", "content-script.js"],
-      "matches": ["*://*/*"]
+      "matches": ["*://*/*"],
+      "all_frames": true
     }
   ]
 }


### PR DESCRIPTION
This change enabled the extension to be used within an DApp that's embedded in a iframe.

As seen in other wallets

https://github.com/leather-io/extension/blob/5c0380f3b5b5f2d19f817b014035b9cdeecc43cc/scripts/generate-manifest.js#L101

https://github.com/MetaMask/metamask-extension/blob/40b3cd2d0fdb15fe6e19494d3c92fed9ae8e3a15/app/manifest/v3/_base.json#L49